### PR TITLE
Fixing broken links

### DIFF
--- a/docs/doc-completeness.md
+++ b/docs/doc-completeness.md
@@ -95,8 +95,7 @@ List of that are implemented for this check.
 
 ### error-status-code:  Missing Error Status Codes There should be at least one error status code either 4xx or 5xx (or default per the OpenAPI spec / search for Default Response)
 
-- Example here: there are no error codes, only 200 OK https://wwwin-github.cisco.com/stsfartz/oas_docs/blob/master/threatresponse/raw/iroh-enrich.20220324.json#L6698
-
+- There are no error codes, only 200 OK
 
 
 ## Reference Documentation Completeness 

--- a/docs/rest-conventions.md
+++ b/docs/rest-conventions.md
@@ -107,13 +107,13 @@ If you end up opting for a permissive implementation (aka supporting case-insens
 
 ### Inclusive and Bias-Free Naming 
 
-Your API design, documentation, and implementation must use bias-free and inclusive language where customer-facing, and we encourage careful consideration of language choice in source code also. Specifically, eliminate the use of "master/slave" and "whitelist/blacklist." Refer to the [API Documentation Inclusive and Bias-free Language section](../products/documenting.md#inclusive-and-bias-free-language) for guidance on replacements and alternatives.
+Your API design, documentation, and implementation must use bias-free and inclusive language where customer-facing, and we encourage careful consideration of language choice in source code also. Specifically, eliminate the use of "master/slave" and "whitelist/blacklist." Refer to the [Cisco API Guidelines Inclusive and Bias-free Language](https://developer.cisco.com/api-guidelines/#!apix-documentation/documenting-apis) for guidance on replacements and alternatives.
 
 ## REST Representations
 
 ### Encoding
 
-The format of representations used in request/responses should be based on established industry or domain standards. For example, RESTCONF defines a standard for Network Devices based on YANG. Check [Networking Fundamentals](../devices/fundamentals.md) for prescriptive guidance regarding RESTCONF.
+The format of representations used in request/responses should be based on established industry or domain standards. For example, RESTCONF defines a standard for Network Devices based on YANG. Check [Networking Fundamentals](https://developer.cisco.com/api-guidelines/#!devices-restconf) for prescriptive guidance regarding RESTCONF.
 
 When such standards do not exist, your API should pick among generic structured format such as JSON, YAML or XML.
 
@@ -141,7 +141,7 @@ If this qualification is absent, it is assumed that the entity data is encoded a
 
 **API operations should not return the result as an execution status in the response payloads**
 
-The success or failure of an API request should be reflected in the [HTTP status code](#http-status-code) of the response. In case of error, the response representation should provide additional details about the nature of the failure, as detailed in the [Error Handling](./patterns.md#error-handling) section in REST Patterns.
+The success or failure of an API request should be reflected in the [HTTP status code](#http-status-code) of the response. In case of error, the response representation should provide additional details about the nature of the failure, as detailed in the [Error Handling](https://developer.cisco.com/api-guidelines/#!rest-patterns/error-handling) section in REST Patterns.
 
 ### Returned Collections
 
@@ -173,7 +173,7 @@ When responding with a collection of objects, operations should return an array 
 
 _Note that using an encapsulated array is a pattern which brings extra flexibility to the design of APIs, with the possibility to support capabilities such as providing a count of the returned objects or returning a list of not found items in a query._
 
-APIs should return 'full' representations for singleton or collection responses by default, or may provide clients with the ability to request 'summary' representations including only key fields as a performance optimization for larger collections. See [Partial retrieval](./patterns.md#partial-retrieval) in the REST patterns section for further guidance.
+APIs should return 'full' representations for singleton or collection responses by default, or may provide clients with the ability to request 'summary' representations including only key fields as a performance optimization for larger collections. See [Partial retrieval](https://developer.cisco.com/api-guidelines/#!rest-patterns/partial-retrieval) in the REST patterns section for further guidance.
 
 ### Representation Fields
 
@@ -184,8 +184,7 @@ APIs should return 'full' representations for singleton or collection responses 
 > Linter Rule - API.REST.CONVENTIONS.oas-field-names-lower-camel-case: Representation field names use lowerCamelCase.
 <!-- recostop -->
 
-
-The general recommendation - detailled in the [Designing REST APIs](./designing.md#representation-fields) section - to use lowerCamelCase for capitalization also applies to the fields of your API operations representations.
+The general recommendation - detailled in the [Designing REST APIs](https://developer.cisco.com/api-guidelines/#rest-conventions/representation-fields) section - to use lowerCamelCase for capitalization also applies to the fields of your API operations representations.
 
 When naming representation fields:
 
@@ -235,7 +234,7 @@ Example:
 
 Representations for CRUD-based API Resources must include identifiers, generally as an `id` field. 
 
-Identifiers should be advertised to consumers as opaque, and should not be predictable or associated with the data itself, as detailled in [Constructing resource identifiers](./designing.md#API.REST.DESIGN.02).
+Identifiers should be advertised to consumers as opaque, and should not be predictable or associated with the data itself, as detailled in [Constructing resource identifiers](https://developer.cisco.com/api-guidelines/#!rest-design/constructing-resource-identifiers).
 
 <!-- reco API.REST.CONVENTIONS.10 -->
 <h6 id="API.REST.CONVENTIONS.10"></h6>

--- a/docs/rest-conventions.md
+++ b/docs/rest-conventions.md
@@ -193,8 +193,8 @@ When naming representation fields:
   *  Choose meaningful and succinct names
   *  Don't reuse any names reserved for other purposes
   *  Avoid internal naming conflicts, e.g. reusing names for dissimilar purposes
-  *  [(_INVESTIGATING_)](../introduction.md#classes-of-recommendations)
- Follow [SCIM Schema](http://www.simplecloud.info/specs/draft-scim-core-schema-01.html) naming conventions when a field represents data from a directory system
+  *  Include a [classification label](https://developer.cisco.com/api-guidelines/#!cisco-api-guidelines/classes-of-recommendations) for the field.
+  *  Follow [SCIM Schema](http://www.simplecloud.info/specs/draft-scim-core-schema-01.html) naming conventions when a field represents data from a directory system
 
 <!-- reco API.REST.CONVENTIONS.09 -->
 <h6 id="API.REST.CONVENTIONS.09"></h6>

--- a/docs/rest-style.md
+++ b/docs/rest-style.md
@@ -450,7 +450,7 @@ Your API operations should include a unique `TrackingID` header with every respo
 
 This TrackingID is intended to identify the operation/transaction across time and space, as a key for later support and serviceability needs, including trace log analysis across multiple nodes/instances.
 
-The actual informational content of the `TrackingID` header can be opaque to the API user, but could incorporate multiple pieces of info helpful to the [support team](../products/supporting.md), including:
+The actual informational content of the `TrackingID` header can be opaque to the API user, but could incorporate multiple pieces of info helpful to the API Insights support team, including:
 
 * Processing entity identifier: to identify the operation/node/instance that handled the request (and where the corresponding trace logs would be found)
 * A globally unique transaction identifier: i.e. a UUID

--- a/docs/rest-style.md
+++ b/docs/rest-style.md
@@ -298,7 +298,7 @@ Any request body data accompanying a HEAD request must be ignored by the operati
 
 An API may support OPTIONS requests for scenarios such as:
 
-- Implementing [CORS](https://www.w3.org/TR/cors/) to enable secure browser-based usage of the API, see ["Securing your APIs / CORS"](./security.md#cors-support)
+- Implementing [CORS](https://www.w3.org/TR/cors/) to enable secure browser-based usage of the API, see ["CORS Support"](https://developer.cisco.com/api-guidelines/#rest-security/cors-support)
 - Providing 'discovery' capabilities per resource, primarily for clients to query/negotiate support for particular HTTP verbs and/or request/response content formats, see [RFC-2616](https://tools.ietf.org/html/rfc2616#section-9.2)
 
 Any request body data accompanying an OPTIONS request should be ignored by the operation.
@@ -386,7 +386,7 @@ Accept-Encoding                   | Gzip, deflate                               
 Accept-Language                   | "en", "es", etc.                                 | Specifies the preferred language for the response. Operations are not required to support this, but if an operation supports localization it must do so through the Accept-Language header.
 Accept-Charset                    | Charset type like "UTF-8"                        | Default is UTF-8, but operations should be able to handle ISO-8859-1.
 Content-Type                      | Content type                                     | Mime type of request body (PUT/POST/PATCH)
-If-Match, If-None-Match, If-Range | String                                           | Operations that support updates to resources using optimistic concurrency control must support the [If-Match header](https://tools.ietf.org/html/rfc7232) to do so. Operations may also use other headers related to ETags as long as they follow the HTTP specification. See ["Concurrency Control"](patterns.md#concurrency-control) patterns for more details.
+If-Match, If-None-Match, If-Range | String                                           | Operations that support updates to resources using optimistic concurrency control must support the [If-Match header](https://tools.ietf.org/html/rfc7232) to do so. Operations may also use other headers related to ETags as long as they follow the HTTP specification. See ["Concurrency Control"](https://developer.cisco.com/api-guidelines/#rest-patterns/concurrency-control) patterns for more details.
 
 #### Accept Header
 
@@ -481,7 +481,7 @@ Operations should support the `ETag` header in any HTTP response where it is rea
 
 In cases where `ETag` is supported, such resources should also support `If-Match` and `If-None-Match` request headers, see [HTTP conditional requests](https://tools.ietf.org/html/rfc7232).
 
-Also, refer to the ["Conditional Requests"](patterns.md#conditional-requests) and ["Concurrency Control"](patterns.md#concurrency-control) patterns for more details on how to apply ETags in your design.
+Also, refer to the ["Conditional Requests"](https://developer.cisco.com/api-guidelines/#!rest-patterns/conditional-requests) and ["Concurrency Control"](https://developer.cisco.com/api-guidelines/#rest-patterns/concurrency-control) patterns for more details on how to apply ETags in your design.
 
 **Where caching is not appropriate**, operations must include a `Cache-Control` header (e.g. max-age=0, no-cache, no-store, must-revalidate) and must not include an `ETag` header.
 
@@ -514,7 +514,7 @@ It is possible to filter a collection on several attributes at the same time, an
 - Example with multiple filters: `GET /users?lastName=Doe&firstName=Jane`
 - Example with a repeated attribute: `GET /users?id=234&id=643&id=877`
 
-Check the [Advanced Querying](./patterns.md#advanced-querying) section for querying best practices that go beyond simple filtering.
+Check the [Advanced Querying](https://developer.cisco.com/api-guidelines/#rest-patterns/advanced-querying) section for querying best practices that go beyond simple filtering.
 
 ### Sorting
 
@@ -548,7 +548,7 @@ An `order` parameter m  ay indicate the ascending/descending order of the sortin
 GET /documents?sort=publishedDate&order=desc
 ```
 
-For querying requirements that go beyond simple sort, see the [Query Syntax](./patterns.md#query-syntax-use-cases) section.
+For querying requirements that go beyond simple sort, see the [Query Syntax](https://developer.cisco.com/api-guidelines/#!rest-patterns/query-syntaxes) section.
 
 ### Pagination
 
@@ -704,7 +704,7 @@ The purpose of the `GET` method is to retrieve an API resource.
 
 On success, a status code `200 OK` and a response with the content of the resource is expected, generally represented as a single object or a collection of objects.
 
-In cases where a GET operation returns an empty collection, the `200 OK` status code should be used, with a representation containing an empty  [encapsulated array](./conventions.md#returned-collections), as in the example below:
+In cases where a GET operation returns an empty collection, the `200 OK` status code should be used, with a representation containing an empty  [encapsulated array](https://developer.cisco.com/api-guidelines/#rest-conventions/returned-collections), as in the example below:
 
 ```json
 {
@@ -727,7 +727,7 @@ If the resource was successfully created as part of the execution, a `201 Create
 
 If if an operation attempts to create a sub-resource for a primary resource that is non-existent, `404 Not Found` is the appropriate status code response.
 
-**When invoking functional resources**, `200 OK` status code is generally the appropriate status code for successful execution of 'POST' operations. see [Extending CRUD with Functional Resources](./designing.md#extending-crud-with-functional-resources) for more details.
+**When invoking functional resources**, `200 OK` status code is generally the appropriate status code for successful execution of 'POST' operations. see [Extending CRUD with Functional Resources](https://developer.cisco.com/api-guidelines/#rest-design/extending-crud-with-functional-resources) for more details.
 
 ### PUT Responses
 


### PR DESCRIPTION
I did not fix the following links in this commit:

- https://developer.cisco.com/introduction.md#classes-of-recommendations (I didn't want to interfere with whatever investigation is going on here)
- https://developer.cisco.com/products/supporting.md (Not sure which support document is supposed to be linked here. The api-insights-openapi-rulesets repo doesn't have a support section. Should I link to the api-insights-docs Support section?)