### PR TITLE
Remove ref links & update tests

### DIFF
--- a/api-insights-openapi-ruleset.js
+++ b/api-insights-openapi-ruleset.js
@@ -82,7 +82,7 @@ export default {
     },
     'patch-200-204-success': {
       'description': "PATCH operations return either '200 OK' with full representation or '204 No Content'.",
-      'message': '{{description}}; {{error}}',
+      'message': '{{error}}',
       'severity': 'error',
       'given': "$.paths.*[?( @property === 'patch' )]",
       'then': {
@@ -91,7 +91,7 @@ export default {
     },
     'put-200-204-success': {
       'description': "PUT operations return either '200 OK' with full representation or '204 No Content'.",
-      'message': '{{description}}; {{error}}',
+      'message': '{{error}}',
       'severity': 'error',
       'given': '$.paths.*[?( @property === \'put\' )]',
       'then': {
@@ -254,7 +254,7 @@ export default {
     },
     'date-response-header-requirement': {
       'description': "All responses include a 'Date' header in the GMT timezone and RFC 5322 format.",
-      'message': '{{description}}; {{error}}',
+      'message': '{{description}}',
       'severity': 'error',
       'given': '$.paths.*.*.responses[*]',
       'then': {
@@ -352,7 +352,7 @@ export default {
     },
     'tracking-id-header-requirement': {
       'description': "All responses must include a 'TrackingID' header.",
-      'message': '{{description}}; {{error}}',
+      'message': '{{description}}',
       'severity': 'warn',
       'given': '$.paths.*.*.responses[*]',
       'then': {
@@ -561,7 +561,7 @@ export default {
     },
     'no-crud-verbs': {
       'description': 'Standard CRUD lifecycle operations map to HTTP verbs; Functional resources are used when non-standard CRUD are needed.',
-      'message': '{{description}}; {{error}}',
+      'message': '{{error}}',
       'severity': 'error',
       'given': '$.paths[*~]',
       'then': {
@@ -570,7 +570,7 @@ export default {
     },
     'respond-with-recommended-get-codes': {
       'description': 'My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges',
-      'message': '{{description}}; {{error}}',
+      'message': '{{error}}',
       'severity': 'error',
       'given': "$.paths.*.[?(@property === 'get')].responses.*~",
       'then': [
@@ -584,7 +584,7 @@ export default {
     },
     'respond-with-recommended-post-codes': {
       'description': 'My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges',
-      'message': '{{description}}; {{error}}',
+      'message': '{{error}}',
       'severity': 'error',
       'given': "$.paths.*.[?(@property === 'post')].responses.*~",
       'then': [
@@ -598,7 +598,7 @@ export default {
     },
     'respond-with-recommended-patch-codes': {
       'description': 'My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges',
-      'message': '{{description}}; {{error}}',
+      'message': '{{error}}',
       'severity': 'error',
       'given': "$.paths.*.[?(@property === 'patch')].responses.*~",
       'then': [
@@ -612,7 +612,7 @@ export default {
     },
     'respond-with-recommended-put-codes': {
       'description': 'My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges',
-      'message': '{{description}}; {{error}}',
+      'message': '{{error}}',
       'severity': 'error',
       'given': "$.paths.*.[?(@property === 'put')].responses.*~",
       'then': [
@@ -626,7 +626,7 @@ export default {
     },
     'respond-with-recommended-delete-codes': {
       'description': 'My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges',
-      'message': '{{description}}; {{error}}',
+      'message': '{{error}}',
       'severity': 'error',
       'given': "$.paths.*.[?(@property === 'delete')].responses.*~",
       'then': [
@@ -640,7 +640,7 @@ export default {
     },
     'sort-recommend-order': {
       'description': "Consider using 'order' with 'sort' in this operation.",
-      'message': '{{description}}; {{error}}',
+      'message': '{{error}}',
       'severity': 'hint',
       'given': '$.paths.*.get.parameters',
       'then': {
@@ -649,7 +649,7 @@ export default {
     },
     'oas2-error-message': {
       'description': 'Error representations include a useful human-readable message.',
-      'message': '{{description}}; {{error}}',
+      'message': '{{error}}',
       'severity': 'error',
       'formats': [oas2],
       'given': "$.paths.*[?(@property != 'head')].responses[?(/^4\\d\\d.*$/i.test(@property) || /^5\\d\\d.*$/i.test(@property))]",
@@ -661,7 +661,7 @@ export default {
     },
     'oas3-error-message': {
       'description': 'Error representations include a useful human-readable message.',
-      'message': '{{description}}; {{error}}',
+      'message': '{{error}}',
       'severity': 'error',
       'formats': [oas3],
       'given': "$.paths.*[?(@property != 'head')].responses[?(/^4\\d\\d.*$/i.test(@property) || /^5\\d\\d.*$/i.test(@property))]",
@@ -673,7 +673,7 @@ export default {
     },
     'oas2-error-response-identifier': {
       'description': 'Error representations include an identifier to help with troubleshooting.',
-      'message': '{{description}}; {{error}}',
+      'message': '{{error}}',
       'severity': 'warn',
       'given': "$.paths.*[?(@property !== 'head')].responses[?(/^4\\d\\d.*$/i.test(@property) || /^5\\d\\d.*$/i.test(@property))]",
       'formats': [oas2],
@@ -685,7 +685,7 @@ export default {
     },
     'oas3-error-response-identifier': {
       'description': 'Error representations include an identifier to help with troubleshooting.',
-      'message': '{{description}}; {{error}}',
+      'message': '{{error}}',
       'severity': 'warn',
       'given': "$.paths.*[?(@property !== 'head')].responses[?(/^4\\d\\d.*$/i.test(@property) || /^5\\d\\d.*$/i.test(@property))]",
       'formats': [oas3],
@@ -1049,7 +1049,7 @@ export default {
     },
     'oas2-path-based-versioning-error': {
       'description': 'API uses path-based versioning.',
-      'message': '{{description}}; {{error}}',
+      'message': '{{error}}',
       'severity': 'error',
       'formats': [oas2],
       'given': '$',
@@ -1063,7 +1063,7 @@ export default {
     },
     'oas3-path-based-versioning-error': {
       'description': 'API uses path-based versioning.',
-      'message': '{{description}}; {{error}}',
+      'message': '{{error}}',
       'severity': 'error',
       'formats': [oas3],
       'given': '$',
@@ -1089,7 +1089,7 @@ export default {
     },
     'oas2-path-based-versioning-major-only': {
       'description': 'API shows only major version numbers on the path; not the revision numbers.',
-      'message': '{{description}}; {{error}}',
+      'message': '{{error}}',
       'severity': 'error',
       'formats': [oas2],
       'given': '$',
@@ -1184,7 +1184,7 @@ export default {
     },
     'oas2-acceptable-auth': {
       'description': 'My API authenticates requests using access tokens; NOT username/passwords.',
-      'message': '{{description}}; {{error}}',
+      'message': '{{error}}',
       'severity': 'error',
       'formats': [oas2],
       'given': '$.securityDefinitions.*',
@@ -1194,7 +1194,7 @@ export default {
     },
     'oas3-acceptable-auth': {
       'description': 'My API authenticates requests using access tokens; NOT username/passwords.',
-      'message': '{{description}}; {{error}}',
+      'message': '{{error}}',
       'severity': 'error',
       'formats': [oas3],
       'given': '$.components.securitySchemes.*',
@@ -1236,7 +1236,7 @@ export default {
     },
     'status-code-401': {
       'description': 'A 401 status code is returned when authentication fails.',
-      'message': '{{description}}; {{error}}',
+      'message': '{{description}}',
       'severity': 'error',
       'given': '$.paths.*[?(@.security && @.security.length)]',
       'then': [
@@ -1251,7 +1251,7 @@ export default {
     },
     'status-code-403': {
       'description': 'A 403 status code is returned if a consumer is not authorized to access an operation.',
-      'message': '{{description}}; {{error}}',
+      'message': '{{description}}',
       'severity': 'error',
       'given': '$.paths.*[?(@.security && @.security.length)]',
       'then': [
@@ -1305,7 +1305,7 @@ export default {
       },
     },
     'authenticate-requests': {
-      'description': 'API.REST.SECURITY.03: My API authenticates and authorizes all requests',
+      'description': 'My API authenticates and authorizes all requests.',
       'message': '{{description}}; {{error}}',
       'severity': 'error',
       'given': '$.paths.*.*',
@@ -1325,7 +1325,7 @@ export default {
     },
     'reason-phrase': {
       'description': 'Reason phrase needs to match',
-      'message': '{{description}}; {{error}}',
+      'message': '{{error}}',
       'severity': 'error',
       'given': '$.paths.*.*.responses.*.description',
       'then': [

--- a/contract.js
+++ b/contract.js
@@ -139,8 +139,8 @@ export default {
       },
     },
     'oas2-meta-info': {
-      'description': 'Some meta fields must be present',
-      'message': '{{description}} {{error}}',
+      'description': 'Some meta fields must be present.',
+      'message': '{{description}}; {{error}}',
       'severity': 'error',
       'formats': [oas2],
       'type': 'validation',

--- a/functions/acceptableAuth.js
+++ b/functions/acceptableAuth.js
@@ -46,7 +46,7 @@ export default function (input) {
   if (invalidScheme) {
     return [
       {
-        message: 'My API authenticates requests using access tokens; NOT username/passwords. (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'My API authenticates requests using access tokens; NOT username/passwords.',
       },
     ];
   }

--- a/functions/acceptableAuth.spec.js
+++ b/functions/acceptableAuth.spec.js
@@ -48,7 +48,7 @@ describe('acceptableAuth', () => {
 
     expect(res).toEqual([
       {
-        message: 'My API authenticates requests using access tokens; NOT username/passwords. (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'My API authenticates requests using access tokens; NOT username/passwords.',
       },
     ]);
   });
@@ -68,7 +68,7 @@ describe('acceptableAuth', () => {
 
     expect(res).toEqual([
       {
-        message: 'My API authenticates requests using access tokens; NOT username/passwords. (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'My API authenticates requests using access tokens; NOT username/passwords.',
       },
     ]);
   });
@@ -79,7 +79,7 @@ describe('acceptableAuth', () => {
 
     expect(res).toEqual([
       {
-        message: 'My API authenticates requests using access tokens; NOT username/passwords. (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'My API authenticates requests using access tokens; NOT username/passwords.',
       },
     ]);
   });

--- a/functions/checkForMaxParameterLinkHeaderLikely.spec.js
+++ b/functions/checkForMaxParameterLinkHeaderLikely.spec.js
@@ -23,11 +23,11 @@ const path = [
   '/test',
 ];
 const maxQueryMessage = {
-  message: 'When returning a paginated collection, include a "max" query parameter (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+  message: 'When returning a paginated collection, include a "max" query parameter',
   path: [...path],
 };
 const linkHeaderMessage = {
-  message: 'When returning a paginated collection, include a "Link" header in the response (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+  message: 'When returning a paginated collection, include a "Link" header in the response',
   path: [
     ...path,
     'responses',

--- a/functions/checkForMaxParameterLinkHeaderPossible.spec.js
+++ b/functions/checkForMaxParameterLinkHeaderPossible.spec.js
@@ -23,15 +23,15 @@ const path = [
   '/test',
 ];
 const maxQueryMessage = {
-  message: 'When returning a paginated collection, include a "max" query parameter (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+  message: 'When returning a paginated collection, include a "max" query parameter',
   path: [...path],
 };
 const offsetQueryMessage = {
-  message: 'When supporting offset-based pagination, operations include a "offset" query parameter (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+  message: 'When supporting offset-based pagination, operations include a "offset" query parameter',
   path: [...path],
 };
 const linkHeaderMessage = {
-  message: 'When returning a paginated collection, include a "Link" header in the response (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+  message: 'When returning a paginated collection, include a "Link" header in the response',
   path: [
     ...path,
     'responses',

--- a/functions/checkPathBasedVersioning.js
+++ b/functions/checkPathBasedVersioning.js
@@ -51,7 +51,7 @@ export default function (input, opts) {
   if (!(defaultVersioning || paths || onlyMajor)) {
     return [
       {
-        message: 'API uses path-based versioning. (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'API uses path-based versioning.',
       },
     ];
   }
@@ -60,7 +60,7 @@ export default function (input, opts) {
   if ((defaultVersioning || paths) && onlyMajor) {
     return [
       {
-        message: 'API shows only major version numbers on the path; not the revision numbers. (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'API shows only major version numbers on the path; not the revision numbers.',
       },
     ];
   }

--- a/functions/checkPathBasedVersioning.spec.js
+++ b/functions/checkPathBasedVersioning.spec.js
@@ -17,8 +17,8 @@
  */
 
 import checkPathBasedVersioning from './checkPathBasedVersioning.js';
-const hasVersionErrorMsg = 'API uses path-based versioning. (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)';
-const onlyMajorErrorMsg = 'API shows only major version numbers on the path; not the revision numbers. (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)';
+const hasVersionErrorMsg = 'API uses path-based versioning.';
+const onlyMajorErrorMsg = 'API shows only major version numbers on the path; not the revision numbers.';
 
 describe('checkPathBasedVersioning', () => {
   test('should check version in servers - oas3', () => {

--- a/functions/checkRFC5322RegexCompliance.js
+++ b/functions/checkRFC5322RegexCompliance.js
@@ -43,7 +43,7 @@ export default function (input) {
       if (!regex.exec(sample)) {
         return [
           {
-            message: `The regex pattern used does not pass basic linting sample checks - should have matched case ${ sample } (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)`,
+            message: `The regex pattern used does not pass basic linting sample checks - should have matched case ${ sample }`,
           },
         ];
       }
@@ -54,7 +54,7 @@ export default function (input) {
       if (regex.exec(sample)) {
         return [
           {
-            message: `The regex pattern used does not pass basic linting sample checks - should not have matched case ${ sample } (${ msg }) (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)`,
+            message: `The regex pattern used does not pass basic linting sample checks - should not have matched case ${ sample } (${ msg })`,
           },
         ];
       }
@@ -62,7 +62,7 @@ export default function (input) {
   } catch (err) {
     return [
       {
-        message: 'Failed to parse regex (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Failed to parse regex',
       },
     ];
   }

--- a/functions/checkRFC5322RegexCompliance.spec.js
+++ b/functions/checkRFC5322RegexCompliance.spec.js
@@ -28,7 +28,7 @@ describe('checkRFC5322RegexCompliance', () => {
 
     expect(res).toEqual([
       {
-        message: 'The regex pattern used does not pass basic linting sample checks - should not have matched case Thu 8 Apr 2021 19:06:27 GMT (Comma required after Day of Week) (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'The regex pattern used does not pass basic linting sample checks - should not have matched case Thu 8 Apr 2021 19:06:27 GMT (Comma required after Day of Week)',
       },
     ]);
   });

--- a/functions/correctResponseRange.js
+++ b/functions/correctResponseRange.js
@@ -55,7 +55,7 @@ export default function (input, opts) {
   if (errStatusCodes.length) {
     return [
       {
-        message: `Status Code(s) [${ errStatusCodes.toString() }] must be in the ${ rangeString } ranges: (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)`,
+        message: `Status Code(s) [${ errStatusCodes.toString() }] must be in the ${ rangeString } ranges`,
       },
     ];
   }

--- a/functions/correctResponseRange.spec.js
+++ b/functions/correctResponseRange.spec.js
@@ -59,7 +59,7 @@ describe('correctResponseRange', () => {
 
     expect(res).toEqual([
       {
-        message: 'Status Code(s) [99,100,782] must be in the 2xx/3xx/4xx/5xx ranges: (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Status Code(s) [99,100,782] must be in the 2xx/3xx/4xx/5xx ranges',
       },
     ]);
   });

--- a/functions/hasErrorMessage.js
+++ b/functions/hasErrorMessage.js
@@ -42,7 +42,7 @@ export default function (input, opts, context) {
   if (!errorMessage) {
     return [
       {
-        message: 'Error representations include a useful human-readable message. (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Error representations include a useful human-readable message.',
       },
     ];
   }

--- a/functions/hasErrorMessage.spec.js
+++ b/functions/hasErrorMessage.spec.js
@@ -129,7 +129,7 @@ describe('hasErrorMessage', () => {
 
     expect(res).toEqual([
       {
-        message: 'Error representations include a useful human-readable message. (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Error representations include a useful human-readable message.',
       },
     ]);
   });

--- a/functions/hasRecommendedStatusCodes.js
+++ b/functions/hasRecommendedStatusCodes.js
@@ -86,7 +86,7 @@ export default function (input, opts) {
   if (!acceptableCodes.includes(`${ input }`)) {
     return [
       {
-        message: `${ input } is not an acceptable response code for ${ method.toUpperCase() }. My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges`,
+        message: `${ input } is not an acceptable response code for ${ method.toUpperCase() }. My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges.`,
       },
     ];
   }

--- a/functions/hasRecommendedStatusCodes.js
+++ b/functions/hasRecommendedStatusCodes.js
@@ -86,7 +86,7 @@ export default function (input, opts) {
   if (!acceptableCodes.includes(`${ input }`)) {
     return [
       {
-        message: `${ input } is not an acceptable response code for ${ method.toUpperCase() }. My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)`,
+        message: `${ input } is not an acceptable response code for ${ method.toUpperCase() }. My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges`,
       },
     ];
   }

--- a/functions/hasRecommendedStatusCodes.spec.js
+++ b/functions/hasRecommendedStatusCodes.spec.js
@@ -80,7 +80,7 @@ describe('hasRecommendedStatusCodes', () => {
     for (const res of badCodes) {
       expect(hasRecommendedStatusCodes(res, { method: 'get' })).toEqual([
         {
-          message: `${ res } is not an acceptable response code for GET. My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges`,
+          message: `${ res } is not an acceptable response code for GET. My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges.`,
         },
       ]);
     }
@@ -96,7 +96,7 @@ describe('hasRecommendedStatusCodes', () => {
     for (const res of badCodes) {
       expect(hasRecommendedStatusCodes(res, { method: 'get' })).toEqual([
         {
-          message: `${ res } is not an acceptable response code for GET. My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges`,
+          message: `${ res } is not an acceptable response code for GET. My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges.`,
         },
       ]);
     }
@@ -116,7 +116,7 @@ describe('hasRecommendedStatusCodes', () => {
     for (const res of badCodes) {
       expect(hasRecommendedStatusCodes(res, { method: 'post' })).toEqual([
         {
-          message: `${ res } is not an acceptable response code for POST. My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges`,
+          message: `${ res } is not an acceptable response code for POST. My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges.`,
         },
       ]);
     }
@@ -136,7 +136,7 @@ describe('hasRecommendedStatusCodes', () => {
     for (const res of badCodes) {
       expect(hasRecommendedStatusCodes(res, { method: 'put' })).toEqual([
         {
-          message: `${ res } is not an acceptable response code for PUT. My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges`,
+          message: `${ res } is not an acceptable response code for PUT. My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges.`,
         },
       ]);
     }
@@ -159,7 +159,7 @@ describe('hasRecommendedStatusCodes', () => {
     for (const res of badCodes) {
       expect(hasRecommendedStatusCodes(res, { method: 'patch' })).toEqual([
         {
-          message: `${ res } is not an acceptable response code for PATCH. My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges`,
+          message: `${ res } is not an acceptable response code for PATCH. My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges.`,
         },
       ]);
     }
@@ -182,7 +182,7 @@ describe('hasRecommendedStatusCodes', () => {
     for (const res of badCodes) {
       expect(hasRecommendedStatusCodes(res, { method: 'delete' })).toEqual([
         {
-          message: `${ res } is not an acceptable response code for DELETE. My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges`,
+          message: `${ res } is not an acceptable response code for DELETE. My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges.`,
         },
       ]);
     }

--- a/functions/hasRecommendedStatusCodes.spec.js
+++ b/functions/hasRecommendedStatusCodes.spec.js
@@ -80,7 +80,7 @@ describe('hasRecommendedStatusCodes', () => {
     for (const res of badCodes) {
       expect(hasRecommendedStatusCodes(res, { method: 'get' })).toEqual([
         {
-          message: `${ res } is not an acceptable response code for GET. My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)`,
+          message: `${ res } is not an acceptable response code for GET. My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges`,
         },
       ]);
     }
@@ -96,7 +96,7 @@ describe('hasRecommendedStatusCodes', () => {
     for (const res of badCodes) {
       expect(hasRecommendedStatusCodes(res, { method: 'get' })).toEqual([
         {
-          message: `${ res } is not an acceptable response code for GET. My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)`,
+          message: `${ res } is not an acceptable response code for GET. My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges`,
         },
       ]);
     }
@@ -116,7 +116,7 @@ describe('hasRecommendedStatusCodes', () => {
     for (const res of badCodes) {
       expect(hasRecommendedStatusCodes(res, { method: 'post' })).toEqual([
         {
-          message: `${ res } is not an acceptable response code for POST. My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)`,
+          message: `${ res } is not an acceptable response code for POST. My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges`,
         },
       ]);
     }
@@ -136,7 +136,7 @@ describe('hasRecommendedStatusCodes', () => {
     for (const res of badCodes) {
       expect(hasRecommendedStatusCodes(res, { method: 'put' })).toEqual([
         {
-          message: `${ res } is not an acceptable response code for PUT. My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)`,
+          message: `${ res } is not an acceptable response code for PUT. My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges`,
         },
       ]);
     }
@@ -159,7 +159,7 @@ describe('hasRecommendedStatusCodes', () => {
     for (const res of badCodes) {
       expect(hasRecommendedStatusCodes(res, { method: 'patch' })).toEqual([
         {
-          message: `${ res } is not an acceptable response code for PATCH. My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)`,
+          message: `${ res } is not an acceptable response code for PATCH. My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges`,
         },
       ]);
     }
@@ -182,7 +182,7 @@ describe('hasRecommendedStatusCodes', () => {
     for (const res of badCodes) {
       expect(hasRecommendedStatusCodes(res, { method: 'delete' })).toEqual([
         {
-          message: `${ res } is not an acceptable response code for DELETE. My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)`,
+          message: `${ res } is not an acceptable response code for DELETE. My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges`,
         },
       ]);
     }

--- a/functions/includeAll.js
+++ b/functions/includeAll.js
@@ -34,7 +34,7 @@ module.exports = function (targetVal, opts) {
   if (values.length === 0) {
     return [
       {
-        message: 'opts.values is required to be an non-empty array',
+        message: 'opts.values is required to be an non-empty array.',
       },
     ];
   }
@@ -53,7 +53,7 @@ module.exports = function (targetVal, opts) {
   if (missing.length > 0) {
     return [
       {
-        message: `The following values must be incuded: ${ missing.toString() }.`,
+        message: `The following values must be included: ${ missing.toString() }.`,
       },
     ];
   }

--- a/functions/includeAll.spec.js
+++ b/functions/includeAll.spec.js
@@ -66,7 +66,7 @@ describe('includeAll', () => {
 
     expect(res).toEqual([
       {
-        message: 'opts.values is required to be an non-empty array',
+        message: 'opts.values is required to be an non-empty array.',
       },
     ]);
   });
@@ -81,7 +81,7 @@ describe('includeAll', () => {
 
     expect(res).toEqual([
       {
-        message: 'The following values must be incuded: info,title.',
+        message: 'The following values must be included: info,title.',
       },
     ]);
   });

--- a/functions/noCrudVerbs.js
+++ b/functions/noCrudVerbs.js
@@ -27,7 +27,7 @@ export default function (input) {
   if (foundVerb) {
     return [
       {
-        message: 'Standard CRUD lifecycle operations map to HTTP verbs; Functional resources are used when non-standard CRUD are needed',
+        message: 'Standard CRUD lifecycle operations map to HTTP verbs; Functional resources are used when non-standard CRUD are needed.',
       },
     ];
   }

--- a/functions/noCrudVerbs.js
+++ b/functions/noCrudVerbs.js
@@ -27,7 +27,7 @@ export default function (input) {
   if (foundVerb) {
     return [
       {
-        message: 'Standard CRUD lifecycle operations map to HTTP verbs; Functional resources are used when non-standard CRUD are needed (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Standard CRUD lifecycle operations map to HTTP verbs; Functional resources are used when non-standard CRUD are needed',
       },
     ];
   }

--- a/functions/resourcePasCamelCase.js
+++ b/functions/resourcePasCamelCase.js
@@ -67,7 +67,7 @@ export default function (input, opts) {
     if (_node && !isPascalOrCamelCase(_node)) {
       // user will have to iteratively resolve issues in the same string
       result.push({
-        message: `${ _node } must be PasCamelCase: (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)`,
+        message: `${ _node } must be PasCamelCase`,
       });
     }
   }

--- a/functions/resourcePasCamelCase.spec.js
+++ b/functions/resourcePasCamelCase.spec.js
@@ -69,28 +69,28 @@ describe('resourcePasCamelCase', () => {
 
     expect(res).toEqual([
       {
-        message: '30DaysCount must be PasCamelCase: (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: '30DaysCount must be PasCamelCase',
       },
     ]);
 
     res = resourcePasCamelCase('30LessThan60DaysCount');
     expect(res).toEqual([
       {
-        message: '30LessThan60DaysCount must be PasCamelCase: (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: '30LessThan60DaysCount must be PasCamelCase',
       },
     ]);
 
     res = resourcePasCamelCase('60LessThan90DaysCount');
     expect(res).toEqual([
       {
-        message: '60LessThan90DaysCount must be PasCamelCase: (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: '60LessThan90DaysCount must be PasCamelCase',
       },
     ]);
 
     res = resourcePasCamelCase('90DaysCount');
     expect(res).toEqual([
       {
-        message: '90DaysCount must be PasCamelCase: (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: '90DaysCount must be PasCamelCase',
       },
     ]);
   });
@@ -100,21 +100,21 @@ describe('resourcePasCamelCase', () => {
 
     expect(res).toEqual([
       {
-        message: 'THISISALLCAPS must be PasCamelCase: (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'THISISALLCAPS must be PasCamelCase',
       },
     ]);
 
     res = resourcePasCamelCase('this_is_snake_case');
     expect(res).toEqual([
       {
-        message: 'this_is_snake_case must be PasCamelCase: (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'this_is_snake_case must be PasCamelCase',
       },
     ]);
 
     res = resourcePasCamelCase('THISHastoBePasCamelCase?!1');
     expect(res).toEqual([
       {
-        message: 'THISHastoBePasCamelCase?!1 must be PasCamelCase: (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'THISHastoBePasCamelCase?!1 must be PasCamelCase',
       },
     ]);
   });

--- a/test/authenticate-requests.spec.js
+++ b/test/authenticate-requests.spec.js
@@ -38,7 +38,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'API.REST.SECURITY.03: My API authenticates and authorizes all requests (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'API.REST.SECURITY.03: My API authenticates and authorizes all requests; "get.security" property must be truthy',
         path: [
           'paths',
           '/test',
@@ -58,7 +58,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'API.REST.SECURITY.03: My API authenticates and authorizes all requests (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'API.REST.SECURITY.03: My API authenticates and authorizes all requests; "post.security" property must be truthy',
         path: [
           'paths',
           '/test',
@@ -78,7 +78,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'API.REST.SECURITY.03: My API authenticates and authorizes all requests (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'API.REST.SECURITY.03: My API authenticates and authorizes all requests; "put.security" property must be truthy',
         path: [
           'paths',
           '/test',
@@ -98,7 +98,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'API.REST.SECURITY.03: My API authenticates and authorizes all requests (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'API.REST.SECURITY.03: My API authenticates and authorizes all requests; "delete.security" property must be truthy',
         path: [
           'paths',
           '/test',
@@ -118,7 +118,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'API.REST.SECURITY.03: My API authenticates and authorizes all requests (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'API.REST.SECURITY.03: My API authenticates and authorizes all requests; "options.security" property must be truthy',
         path: [
           'paths',
           '/test',

--- a/test/authenticate-requests.spec.js
+++ b/test/authenticate-requests.spec.js
@@ -38,7 +38,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'API.REST.SECURITY.03: My API authenticates and authorizes all requests; "get.security" property must be truthy',
+        message: 'My API authenticates and authorizes all requests.; "get.security" property must be truthy',
         path: [
           'paths',
           '/test',
@@ -58,7 +58,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'API.REST.SECURITY.03: My API authenticates and authorizes all requests; "post.security" property must be truthy',
+        message: 'My API authenticates and authorizes all requests.; "post.security" property must be truthy',
         path: [
           'paths',
           '/test',
@@ -78,7 +78,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'API.REST.SECURITY.03: My API authenticates and authorizes all requests; "put.security" property must be truthy',
+        message: 'My API authenticates and authorizes all requests.; "put.security" property must be truthy',
         path: [
           'paths',
           '/test',
@@ -98,7 +98,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'API.REST.SECURITY.03: My API authenticates and authorizes all requests; "delete.security" property must be truthy',
+        message: 'My API authenticates and authorizes all requests.; "delete.security" property must be truthy',
         path: [
           'paths',
           '/test',
@@ -118,7 +118,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'API.REST.SECURITY.03: My API authenticates and authorizes all requests; "options.security" property must be truthy',
+        message: 'My API authenticates and authorizes all requests.; "options.security" property must be truthy',
         path: [
           'paths',
           '/test',

--- a/test/date-response-header-format-pattern-requirement.spec.js
+++ b/test/date-response-header-format-pattern-requirement.spec.js
@@ -36,7 +36,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'All \'Date\' response headers should use a custom pattern match for RFC 5322. date-time or other given formats should not be used (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'All responses include a \'Date\' header in the GMT timezone and RFC 5322 format.; "schema.pattern" property must be truthy',
         path: [
           'paths',
           '/test',
@@ -61,7 +61,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'All \'Date\' response headers should use a custom pattern match for RFC 5322. date-time or other given formats should not be used (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'All responses include a \'Date\' header in the GMT timezone and RFC 5322 format.; "format" property must be falsy',
         path: [
           'paths',
           '/test',
@@ -87,7 +87,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'All \'Date\' response headers should use a custom pattern match for RFC 5322. date-time or other given formats should not be used (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'All responses include a \'Date\' header in the GMT timezone and RFC 5322 format.; "schema.pattern" property must be truthy',
         path: [
           'paths',
           '/anotherTest',

--- a/test/date-response-header-regex-check.spec.js
+++ b/test/date-response-header-regex-check.spec.js
@@ -36,7 +36,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'The regex pattern used does not pass basic linting sample checks - should not have matched case Thu 8 Apr 2021 19:06:27 GMT (Comma required after Day of Week) (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'All responses include a \'Date\' header in the GMT timezone and RFC 5322 format.; The regex pattern used does not pass basic linting sample checks - should not have matched case Thu 8 Apr 2021 19:06:27 GMT (Comma required after Day of Week)',
         path: [
           'paths',
           '/test',

--- a/test/date-response-header-requirement.spec.js
+++ b/test/date-response-header-requirement.spec.js
@@ -36,7 +36,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'All responses include a \'Date\' header in the GMT timezone and RFC 5322 format.; An expected pathway is missing. Prerequisite: "headers", search: "Date"',
+        message: 'All responses include a \'Date\' header in the GMT timezone and RFC 5322 format.',
         path: [
           'paths',
           '/test',
@@ -58,7 +58,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'All responses include a \'Date\' header in the GMT timezone and RFC 5322 format.; An expected pathway is missing. Prerequisite: "headers", search: "Date"',
+        message: 'All responses include a \'Date\' header in the GMT timezone and RFC 5322 format.',
         path: [
           'paths',
           '/test',
@@ -87,7 +87,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'All responses include a \'Date\' header in the GMT timezone and RFC 5322 format.; An expected pathway is missing. Prerequisite: "headers", search: "Date"',
+        message: 'All responses include a \'Date\' header in the GMT timezone and RFC 5322 format.',
         path: [
           'paths',
           '/test',
@@ -109,7 +109,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'All responses include a \'Date\' header in the GMT timezone and RFC 5322 format.; An expected pathway is missing. Prerequisite: "headers", search: "Date"',
+        message: 'All responses include a \'Date\' header in the GMT timezone and RFC 5322 format.',
         path: [
           'paths',
           '/test',

--- a/test/date-response-header-requirement.spec.js
+++ b/test/date-response-header-requirement.spec.js
@@ -36,7 +36,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'All responses must include a \'Date\' header (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'All responses include a \'Date\' header in the GMT timezone and RFC 5322 format.; An expected pathway is missing. Prerequisite: "headers", search: "Date"',
         path: [
           'paths',
           '/test',
@@ -58,7 +58,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'All responses must include a \'Date\' header (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'All responses include a \'Date\' header in the GMT timezone and RFC 5322 format.; An expected pathway is missing. Prerequisite: "headers", search: "Date"',
         path: [
           'paths',
           '/test',
@@ -87,7 +87,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'All responses must include a \'Date\' header (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'All responses include a \'Date\' header in the GMT timezone and RFC 5322 format.; An expected pathway is missing. Prerequisite: "headers", search: "Date"',
         path: [
           'paths',
           '/test',
@@ -109,7 +109,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'All responses must include a \'Date\' header (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'All responses include a \'Date\' header in the GMT timezone and RFC 5322 format.; An expected pathway is missing. Prerequisite: "headers", search: "Date"',
         path: [
           'paths',
           '/test',

--- a/test/delete-204-success.spec.js
+++ b/test/delete-204-success.spec.js
@@ -36,7 +36,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'DELETE operation must return \'204 No Content\' on success (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'DELETE operations return \'204 No Content\' on success.; "responses[204]" property must be truthy',
         path: [
           'paths',
           '/test',

--- a/test/etag-header-match-required.spec.js
+++ b/test/etag-header-match-required.spec.js
@@ -33,10 +33,10 @@ describe(ruleName, () => {
     const spec = await fsPromises.readFile(`${ resPath }/negative.yml`);
     const res = await spectral.run(spec.toString());
 
-    expect(res).toEqual([
+    expect([res[1]]).toEqual([
       {
         code: ruleName,
-        message: 'In cases where ETag is supported, such resources should also support If-Match and If-None-Match request headers (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'In cases where ETag is supported, such resources should also support If-Match and If-None-Match request headers.; "headers.If-None-Match" property must be truthy',
         path: [
           'paths',
           '/test',
@@ -66,7 +66,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'In cases where ETag is supported, such resources should also support If-Match and If-None-Match request headers (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'In cases where ETag is supported, such resources should also support If-Match and If-None-Match request headers.; "headers.If-None-Match" property must be truthy',
         path: [
           'paths',
           '/test',
@@ -89,7 +89,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'In cases where ETag is supported, such resources should also support If-Match and If-None-Match request headers (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'In cases where ETag is supported, such resources should also support If-Match and If-None-Match request headers.; "headers.If-Match" property must be truthy',
         path: [
           'paths',
           '/anotherTest',

--- a/test/head-operations-match-headers-with-get.spec.js
+++ b/test/head-operations-match-headers-with-get.spec.js
@@ -37,7 +37,7 @@ describe(ruleName, () => {
       expect(res).toEqual([
         {
           code: ruleName,
-          message: 'The following headers are missing from the HEAD operation for response code 200: X-RateLimit-Limit (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+          message: 'HEAD operations must return response headers identical to the corresponding GET.; The following headers are missing from the HEAD operation for response code 200: X-RateLimit-Limit',
           path: [
             'paths',
             '/test',
@@ -67,7 +67,7 @@ describe(ruleName, () => {
       expect(res).toEqual([
         {
           code: ruleName,
-          message: 'The HEAD operation for response code 200 is missing a "headers" definition (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+          message: 'HEAD operations must return response headers identical to the corresponding GET.; The HEAD operation for response code 200 is missing a "headers" definition',
           path: [
             'paths',
             '/test',
@@ -116,7 +116,7 @@ describe(ruleName, () => {
       expect(res).toEqual([
         {
           code: ruleName,
-          message: 'The following headers are missing from the HEAD operation for response code 200: X-RateLimit-Limit (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+          message: 'HEAD operations must return response headers identical to the corresponding GET.; The following headers are missing from the HEAD operation for response code 200: X-RateLimit-Limit',
           path: [
             'paths',
             '/test',
@@ -146,7 +146,7 @@ describe(ruleName, () => {
       expect(res).toEqual([
         {
           code: ruleName,
-          message: 'The HEAD operation for response code 200 is missing a "headers" definition (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+          message: 'HEAD operations must return response headers identical to the corresponding GET.; The HEAD operation for response code 200 is missing a "headers" definition',
           path: [
             'paths',
             '/test',

--- a/test/no-crud-verbs.spec.js
+++ b/test/no-crud-verbs.spec.js
@@ -36,7 +36,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'Standard CRUD lifecycle operations map to HTTP verbs; Functional resources are used when non-standard CRUD are needed (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Standard CRUD lifecycle operations map to HTTP verbs; Functional resources are used when non-standard CRUD are needed.; Standard CRUD lifecycle operations map to HTTP verbs; Functional resources are used when non-standard CRUD are needed',
         path: [
           'paths',
           '/test/get',

--- a/test/no-crud-verbs.spec.js
+++ b/test/no-crud-verbs.spec.js
@@ -36,7 +36,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'Standard CRUD lifecycle operations map to HTTP verbs; Functional resources are used when non-standard CRUD are needed.; Standard CRUD lifecycle operations map to HTTP verbs; Functional resources are used when non-standard CRUD are needed',
+        message: 'Standard CRUD lifecycle operations map to HTTP verbs; Functional resources are used when non-standard CRUD are needed.',
         path: [
           'paths',
           '/test/get',

--- a/test/no-etag-cache-control-header-required.spec.js
+++ b/test/no-etag-cache-control-header-required.spec.js
@@ -36,7 +36,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'Where caching is not appropriate, operations must include a Cache-Control header (e.g. max-age=0, no-cache, no-store, must-revalidate) and must not include an ETag header (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Where caching is not appropriate, operations must include a Cache-Control header (e.g. max-age=0, no-cache, no-store, must-revalidate) and must not include an ETag header.; "headers.Cache-Control" property must be truthy',
         path: [
           'paths',
           '/test',

--- a/test/oas2-application-json-charset-utf8-required.spec.js
+++ b/test/oas2-application-json-charset-utf8-required.spec.js
@@ -37,7 +37,7 @@ describe('ruleName', () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'JSON representations should be declared using \'application/json\' or \'application/json; charset=UTF-8\' media types (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'JSON representations should be declared using \'application/json\' or \'application/json; charset=UTF-8\' media types.; "application/json; charset=utf-16" must not match the pattern "^application/json; charset=(?![Uu][Tt][Ff]-8$)"',
         path: [
           'paths',
           '/test',
@@ -59,7 +59,7 @@ describe('ruleName', () => {
       },
       {
         code: ruleName,
-        message: 'JSON representations should be declared using \'application/json\' or \'application/json; charset=UTF-8\' media types (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'JSON representations should be declared using \'application/json\' or \'application/json; charset=UTF-8\' media types.; "application/json; charset=utf-16" must not match the pattern "^application/json; charset=(?![Uu][Tt][Ff]-8$)"',
         path: [
           'paths',
           '/test',

--- a/test/oas2-array-plural-representation.spec.js
+++ b/test/oas2-array-plural-representation.spec.js
@@ -37,7 +37,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'Representation fields use plural noun names for collections (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Representation fields use plural noun names for collections.; device should be plural.',
         path: [
           'paths',
           '/test',
@@ -62,7 +62,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'Representation fields use plural noun names for collections (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Representation fields use plural noun names for collections.; contract should be plural.',
         path: [
           'paths',
           '/test',
@@ -90,7 +90,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'Representation fields use plural noun names for collections (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Representation fields use plural noun names for collections.; balance should be plural.',
         path: [
           'paths',
           '/test',

--- a/test/oas2-collections-returned-as-arrays.spec.js
+++ b/test/oas2-collections-returned-as-arrays.spec.js
@@ -37,7 +37,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'Collections should be encapsulated within an object. Do not return un-encapsulated arrays (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Collections are returned as arrays encapsulated with a named field such as \'items\'.; "array" must not match the pattern "^array$"',
         path: [
           'paths',
           '/test',
@@ -68,7 +68,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'Collections should be encapsulated within an object. Do not return un-encapsulated arrays (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Collections are returned as arrays encapsulated with a named field such as \'items\'.; "array" must not match the pattern "^array$"',
         path: [
           'paths',
           '/test',
@@ -92,7 +92,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'Collections should be encapsulated within an object. Do not return un-encapsulated arrays (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Collections are returned as arrays encapsulated with a named field such as \'items\'.; "array" must not match the pattern "^array$"',
         path: [
           'paths',
           '/test',

--- a/test/oas2-date-fields-iso-format.spec.js
+++ b/test/oas2-date-fields-iso-format.spec.js
@@ -38,7 +38,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'Representation fields use strings in \'iso-date-time\' format (RFC-3339) for date/time (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Representation fields use strings in \'iso-date-time\' format (RFC-3339) for date/time.; Field timestamp should be type "string" with a format of "date-time".',
         path: [
           'paths',
           '/test',
@@ -66,7 +66,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'Representation fields use strings in \'iso-date-time\' format (RFC-3339) for date/time (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Representation fields use strings in \'iso-date-time\' format (RFC-3339) for date/time.; Field requestDate should be type "string" with a format of "date-time".',
         path: [
           'paths',
           '/test',
@@ -91,7 +91,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'Representation fields use strings in \'iso-date-time\' format (RFC-3339) for date/time (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Representation fields use strings in \'iso-date-time\' format (RFC-3339) for date/time.; Field date should be type "string" with a format of "date-time".',
         path: [
           'paths',
           '/test',
@@ -116,7 +116,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'Representation fields use strings in \'iso-date-time\' format (RFC-3339) for date/time (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Representation fields use strings in \'iso-date-time\' format (RFC-3339) for date/time.; Field dates\'s items should be type "string" with a format of "date-time".',
         path: [
           'paths',
           '/test',

--- a/test/oas2-error-message.spec.js
+++ b/test/oas2-error-message.spec.js
@@ -37,7 +37,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'Error representations include a useful human-readable message. (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Error representations include a useful human-readable message.; Error representations include a useful human-readable message.',
         path: [
           'paths',
           '/test',
@@ -59,7 +59,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'Error representations include a useful human-readable message. (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Error representations include a useful human-readable message.; Error representations include a useful human-readable message.',
         path: [
           'paths',
           '/test',
@@ -100,7 +100,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'Error representations include a useful human-readable message. (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Error representations include a useful human-readable message.; Error representations include a useful human-readable message.',
         path: [
           'paths',
           '/test',
@@ -122,7 +122,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'Error representations include a useful human-readable message. (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Error representations include a useful human-readable message.; Error representations include a useful human-readable message.',
         path: [
           'paths',
           '/test',

--- a/test/oas2-error-message.spec.js
+++ b/test/oas2-error-message.spec.js
@@ -37,7 +37,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'Error representations include a useful human-readable message.; Error representations include a useful human-readable message.',
+        message: 'Error representations include a useful human-readable message.',
         path: [
           'paths',
           '/test',
@@ -59,7 +59,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'Error representations include a useful human-readable message.; Error representations include a useful human-readable message.',
+        message: 'Error representations include a useful human-readable message.',
         path: [
           'paths',
           '/test',
@@ -100,7 +100,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'Error representations include a useful human-readable message.; Error representations include a useful human-readable message.',
+        message: 'Error representations include a useful human-readable message.',
         path: [
           'paths',
           '/test',
@@ -122,7 +122,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'Error representations include a useful human-readable message.; Error representations include a useful human-readable message.',
+        message: 'Error representations include a useful human-readable message.',
         path: [
           'paths',
           '/test',

--- a/test/oas2-error-response-identifier.spec.js
+++ b/test/oas2-error-response-identifier.spec.js
@@ -38,7 +38,7 @@ describe(ruleName, () => {
       expect(res).toEqual([
         {
           code: ruleName,
-          message: 'Error representations include an identifier to help with troubleshooting.; Error representations include an identifier to help with troubleshooting.',
+          message: 'Error representations include an identifier to help with troubleshooting.',
           path: [
             'paths',
             '/test',
@@ -60,7 +60,7 @@ describe(ruleName, () => {
         },
         {
           code: ruleName,
-          message: 'Error representations include an identifier to help with troubleshooting.; Error representations include an identifier to help with troubleshooting.',
+          message: 'Error representations include an identifier to help with troubleshooting.',
           path: [
             'paths',
             '/test',

--- a/test/oas2-error-response-identifier.spec.js
+++ b/test/oas2-error-response-identifier.spec.js
@@ -38,7 +38,7 @@ describe(ruleName, () => {
       expect(res).toEqual([
         {
           code: ruleName,
-          message: 'Error representations include an identifier to help with troubleshooting (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+          message: 'Error representations include an identifier to help with troubleshooting.; Error representations include an identifier to help with troubleshooting.',
           path: [
             'paths',
             '/test',
@@ -60,7 +60,7 @@ describe(ruleName, () => {
         },
         {
           code: ruleName,
-          message: 'Error representations include an identifier to help with troubleshooting (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+          message: 'Error representations include an identifier to help with troubleshooting.; Error representations include an identifier to help with troubleshooting.',
           path: [
             'paths',
             '/test',

--- a/test/oas2-field-names-pas-camel-case.spec.js
+++ b/test/oas2-field-names-pas-camel-case.spec.js
@@ -37,7 +37,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'user_id (paths./test.post.parameters.0.name) field is not PasCamelCase (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Representation field names use PasCamelCase.; user_id (paths./test.post.parameters.0.name)',
         path: [
           'paths',
           '/test',
@@ -59,7 +59,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'MYData (paths./test.post.parameters.1.schema.properties.MYData) field is not PasCamelCase (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Representation field names use PasCamelCase.; MYData (paths./test.post.parameters.1.schema.properties.MYData)',
         path: [
           'paths',
           '/test',
@@ -85,7 +85,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'MYData (paths./test.post.responses.200.schema.items.properties.MYData) field is not PasCamelCase (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Representation field names use PasCamelCase.; MYData (paths./test.post.responses.200.schema.items.properties.MYData)',
         path: [
           'paths',
           '/test',
@@ -120,7 +120,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'snake_case (paths./test.get.responses.200.schema.items.properties.snake_case) field is not PasCamelCase (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Representation field names use PasCamelCase.; snake_case (paths./test.get.responses.200.schema.items.properties.snake_case)',
         path: [
           'paths',
           '/test',

--- a/test/oas2-get-collection-max-parameter-link-header-required-likely.spec.js
+++ b/test/oas2-get-collection-max-parameter-link-header-required-likely.spec.js
@@ -38,7 +38,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'When returning a paginated collection, include a "max" query parameter (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Pagination is designed using a \'max\' query parameter and \'Link\' headers per RFC 5988.; When returning a paginated collection, include a "max" query parameter',
         path: [
           'paths',
           '/test',
@@ -58,7 +58,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'When returning a paginated collection, include a "Link" header in the response (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Pagination is designed using a \'max\' query parameter and \'Link\' headers per RFC 5988.; When returning a paginated collection, include a "Link" header in the response',
         path: [
           'paths',
           '/test',
@@ -87,7 +87,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'When returning a paginated collection, include a "max" query parameter (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Pagination is designed using a \'max\' query parameter and \'Link\' headers per RFC 5988.; When returning a paginated collection, include a "max" query parameter',
         path: [
           'paths',
           '/test',
@@ -107,7 +107,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'When returning a paginated collection, include a "Link" header in the response (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Pagination is designed using a \'max\' query parameter and \'Link\' headers per RFC 5988.; When returning a paginated collection, include a "Link" header in the response',
         path: [
           'paths',
           '/test',
@@ -142,7 +142,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'When returning a paginated collection, include a "max" query parameter (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Pagination is designed using a \'max\' query parameter and \'Link\' headers per RFC 5988.; When returning a paginated collection, include a "max" query parameter',
         path: [
           'paths',
           '/test',
@@ -169,7 +169,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'When returning a paginated collection, include a "Link" header in the response (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Pagination is designed using a \'max\' query parameter and \'Link\' headers per RFC 5988.; When returning a paginated collection, include a "Link" header in the response',
         path: [
           'paths',
           '/test',
@@ -198,7 +198,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'When returning a paginated collection, include a "max" query parameter (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Pagination is designed using a \'max\' query parameter and \'Link\' headers per RFC 5988.; When returning a paginated collection, include a "max" query parameter',
         path: [
           'paths',
           '/test/{id}/children',
@@ -218,7 +218,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'When returning a paginated collection, include a "Link" header in the response (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Pagination is designed using a \'max\' query parameter and \'Link\' headers per RFC 5988.; When returning a paginated collection, include a "Link" header in the response',
         path: [
           'paths',
           '/test/{id}/children',

--- a/test/oas2-get-collection-max-parameter-link-header-required-possible.spec.js
+++ b/test/oas2-get-collection-max-parameter-link-header-required-possible.spec.js
@@ -38,7 +38,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'When returning a paginated collection, include a "max" query parameter (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Pagination is designed using a \'max\' query parameter and \'Link\' headers per RFC 5988.; When returning a paginated collection, include a "max" query parameter',
         path: [
           'paths',
           '/test',
@@ -58,7 +58,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'When supporting offset-based pagination, operations include a "offset" query parameter (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Pagination is designed using a \'max\' query parameter and \'Link\' headers per RFC 5988.; When supporting offset-based pagination, operations include a "offset" query parameter',
         path: [
           'paths',
           '/test',
@@ -78,7 +78,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'When returning a paginated collection, include a "Link" header in the response (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Pagination is designed using a \'max\' query parameter and \'Link\' headers per RFC 5988.; When returning a paginated collection, include a "Link" header in the response',
         path: [
           'paths',
           '/test',
@@ -107,7 +107,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'When returning a paginated collection, include a "max" query parameter (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Pagination is designed using a \'max\' query parameter and \'Link\' headers per RFC 5988.; When returning a paginated collection, include a "max" query parameter',
         path: [
           'paths',
           '/test',
@@ -127,7 +127,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'When supporting offset-based pagination, operations include a "offset" query parameter (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Pagination is designed using a \'max\' query parameter and \'Link\' headers per RFC 5988.; When supporting offset-based pagination, operations include a "offset" query parameter',
         path: [
           'paths',
           '/test',
@@ -147,7 +147,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'When returning a paginated collection, include a "Link" header in the response (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Pagination is designed using a \'max\' query parameter and \'Link\' headers per RFC 5988.; When returning a paginated collection, include a "Link" header in the response',
         path: [
           'paths',
           '/test',
@@ -176,7 +176,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'When returning a paginated collection, include a "max" query parameter (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Pagination is designed using a \'max\' query parameter and \'Link\' headers per RFC 5988.; When returning a paginated collection, include a "max" query parameter',
         path: [
           'paths',
           '/test',
@@ -196,7 +196,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'When supporting offset-based pagination, operations include a "offset" query parameter (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Pagination is designed using a \'max\' query parameter and \'Link\' headers per RFC 5988.; When supporting offset-based pagination, operations include a "offset" query parameter',
         path: [
           'paths',
           '/test',
@@ -216,7 +216,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'When returning a paginated collection, include a "Link" header in the response (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Pagination is designed using a \'max\' query parameter and \'Link\' headers per RFC 5988.; When returning a paginated collection, include a "Link" header in the response',
         path: [
           'paths',
           '/test',
@@ -245,7 +245,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'When returning a paginated collection, include a "max" query parameter (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Pagination is designed using a \'max\' query parameter and \'Link\' headers per RFC 5988.; When returning a paginated collection, include a "max" query parameter',
         path: [
           'paths',
           '/test',
@@ -272,7 +272,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'When supporting offset-based pagination, operations include a "offset" query parameter (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Pagination is designed using a \'max\' query parameter and \'Link\' headers per RFC 5988.; When supporting offset-based pagination, operations include a "offset" query parameter',
         path: [
           'paths',
           '/test',
@@ -299,7 +299,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'When returning a paginated collection, include a "Link" header in the response (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Pagination is designed using a \'max\' query parameter and \'Link\' headers per RFC 5988.; When returning a paginated collection, include a "Link" header in the response',
         path: [
           'paths',
           '/test',
@@ -328,7 +328,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'When returning a paginated collection, include a "max" query parameter (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Pagination is designed using a \'max\' query parameter and \'Link\' headers per RFC 5988.; When returning a paginated collection, include a "max" query parameter',
         path: [
           'paths',
           '/test/{id}/children',
@@ -348,7 +348,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'When supporting offset-based pagination, operations include a "offset" query parameter (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Pagination is designed using a \'max\' query parameter and \'Link\' headers per RFC 5988.; When supporting offset-based pagination, operations include a "offset" query parameter',
         path: [
           'paths',
           '/test/{id}/children',
@@ -368,7 +368,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'When returning a paginated collection, include a "Link" header in the response (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Pagination is designed using a \'max\' query parameter and \'Link\' headers per RFC 5988.; When returning a paginated collection, include a "Link" header in the response',
         path: [
           'paths',
           '/test/{id}/children',

--- a/test/oas2-get-collection-sort-parameter.spec.js
+++ b/test/oas2-get-collection-sort-parameter.spec.js
@@ -38,7 +38,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'It is recommended to add a "sort" query parameter to sort this collection (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Sorting collections is designed with a \'sort\' query parameter.; It is recommended to add a "sort" query parameter to sort this collection',
         path: [
           'paths',
           '/test',
@@ -65,7 +65,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'It is recommended to add a "sort" query parameter to sort this collection (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Sorting collections is designed with a \'sort\' query parameter.; It is recommended to add a "sort" query parameter to sort this collection',
         path: [
           'paths',
           '/test',

--- a/test/oas2-head-operations-no-body.spec.js
+++ b/test/oas2-head-operations-no-body.spec.js
@@ -37,7 +37,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'HEAD operations with a corresponding GET operation must return no body content (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'HEAD operations with a corresponding GET operation must return no body content.; "schema" property must be falsy',
         path: [
           'paths',
           '/test',

--- a/test/oas2-https-only.spec.js
+++ b/test/oas2-https-only.spec.js
@@ -37,7 +37,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'My API supports HTTPS only. (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'My API supports HTTPS only.; "http" must match the pattern "^https$"',
         path: [
           'schemes',
           '1',

--- a/test/oas2-no-boolean-string-enums.spec.js
+++ b/test/oas2-no-boolean-string-enums.spec.js
@@ -37,7 +37,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'Representation fields use format-native true/false values for booleans (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Representation fields use format-native true/false values for booleans.; Given matches target enums.',
         path: [
           'paths',
           '/test',
@@ -70,7 +70,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'Representation fields use format-native true/false values for booleans (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Representation fields use format-native true/false values for booleans.; Given matches target enums.',
         path: [
           'paths',
           '/test',
@@ -103,7 +103,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'Representation fields use format-native true/false values for booleans (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Representation fields use format-native true/false values for booleans.; Given matches target enums.',
         path: [
           'paths',
           '/test',
@@ -137,7 +137,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'Representation fields use format-native true/false values for booleans (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Representation fields use format-native true/false values for booleans.; Given matches target enums.',
         path: [
           'paths',
           '/test',
@@ -174,7 +174,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'Representation fields use format-native true/false values for booleans (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Representation fields use format-native true/false values for booleans.; Given matches target enums.',
         path: [
           'paths',
           '/test',
@@ -208,7 +208,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'Representation fields use format-native true/false values for booleans (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Representation fields use format-native true/false values for booleans.; Given matches target enums.',
         path: [
           'paths',
           '/test',

--- a/test/oas2-order-parameter-asc-desc.spec.js
+++ b/test/oas2-order-parameter-asc-desc.spec.js
@@ -37,7 +37,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'Ordering collections is designed with an \'order\' query parameter specifying \'asc\' or \'desc\' (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Ordering collections is designed with an \'order\' query parameter specifying \'asc\' or \'desc\'.; "integer" must match the pattern "^string$"',
         path: [
           'paths',
           '/test',
@@ -67,7 +67,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'Ordering collections is designed with an \'order\' query parameter specifying \'asc\' or \'desc\' (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Ordering collections is designed with an \'order\' query parameter specifying \'asc\' or \'desc\'.; Given does not match target enums.',
         path: [
           'paths',
           '/test',

--- a/test/oas2-path-based-versioning-error.spec.js
+++ b/test/oas2-path-based-versioning-error.spec.js
@@ -37,7 +37,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'API uses path-based versioning. (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'API uses path-based versioning.; API uses path-based versioning.',
         path: [],
         range: {
           start: {

--- a/test/oas2-path-based-versioning-error.spec.js
+++ b/test/oas2-path-based-versioning-error.spec.js
@@ -37,7 +37,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'API uses path-based versioning.; API uses path-based versioning.',
+        message: 'API uses path-based versioning.',
         path: [],
         range: {
           start: {

--- a/test/oas2-path-based-versioning-major-only.spec.js
+++ b/test/oas2-path-based-versioning-major-only.spec.js
@@ -37,7 +37,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'API shows only major version numbers on the path; not the revision numbers.; API shows only major version numbers on the path; not the revision numbers.',
+        message: 'API shows only major version numbers on the path; not the revision numbers.',
         path: [],
         range: {
           start: {

--- a/test/oas2-path-based-versioning-major-only.spec.js
+++ b/test/oas2-path-based-versioning-major-only.spec.js
@@ -37,7 +37,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'API shows only major version numbers on the path; not the revision numbers. (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'API shows only major version numbers on the path; not the revision numbers.; API shows only major version numbers on the path; not the revision numbers.',
         path: [],
         range: {
           start: {

--- a/test/oas2-post-201-created.spec.js
+++ b/test/oas2-post-201-created.spec.js
@@ -37,7 +37,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'POST operations which create objects return 201 Created, with a full or reference-only representation. (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'POST operations which create objects return 201 Created, with a full or reference-only representation.; "[201].schema" property must be truthy',
         path: [
           'paths',
           '/test',
@@ -59,7 +59,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'POST operations which create objects return 201 Created, with a full or reference-only representation. (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'POST operations which create objects return 201 Created, with a full or reference-only representation.; "[201].schema" property must be truthy',
         path: [
           'paths',
           '/other/test',

--- a/test/oas2-request-header-accept-charset-default-required.spec.js
+++ b/test/oas2-request-header-accept-charset-default-required.spec.js
@@ -38,7 +38,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'Accept-Charset must have a default defined (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'HTTP headers follow the syntax specified in the corresponding RFCs.; "[0].default" property must be truthy',
         path: [
           'paths',
           '/test',

--- a/test/oas2-request-header-accept-charset-valid-default.spec.js
+++ b/test/oas2-request-header-accept-charset-valid-default.spec.js
@@ -38,7 +38,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'Default for Accept-Charset must be UTF-8 (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'HTTP headers follow the syntax specified in the corresponding RFCs.; "test" must match the pattern "^[Uu][Tt][Ff]-8$"',
         path: [
           'paths',
           '/test',

--- a/test/oas2-request-header-accept-charset-valid-enum.spec.js
+++ b/test/oas2-request-header-accept-charset-valid-enum.spec.js
@@ -38,7 +38,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'Accept-Charset must allow UTF-8 and ISO-8859-1. (The following values are missing from the enum: ISO-8859-1.) (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'HTTP headers follow the syntax specified in the corresponding RFCs.; The following values are missing from the enum: ISO-8859-1.',
         path: [
           'paths',
           '/test',

--- a/test/oas2-request-header-accept-encoding-enum.spec.js
+++ b/test/oas2-request-header-accept-encoding-enum.spec.js
@@ -38,7 +38,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'Accept-Encoding should have a list of accepted values (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'HTTP headers follow the syntax specified in the corresponding RFCs.; "[0].enum" property must be truthy',
         path: [
           'paths',
           '/test',

--- a/test/oas2-request-header-accept-encoding-valid-enum.spec.js
+++ b/test/oas2-request-header-accept-encoding-valid-enum.spec.js
@@ -38,7 +38,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'Accept-Encoding accepts a value that is not valid per RFC 7231. (The following values must be removed: notvalid.) (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer) Please see https://www.iana.org/assignments/http-parameters/http-parameters.xhtml',
+        message: 'HTTP headers follow the syntax specified in the corresponding RFCs.; The following values must be removed: notvalid.',
         path: [
           'paths',
           '/test',

--- a/test/oas2-request-header-accept-language-enum.spec.js
+++ b/test/oas2-request-header-accept-language-enum.spec.js
@@ -38,7 +38,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'Accept-Language should have a list of accepted values (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'HTTP headers follow the syntax specified in the corresponding RFCs.; "[0].enum" property must be truthy',
         path: [
           'paths',
           '/test',

--- a/test/oas2-request-header-date-correct-regex.spec.js
+++ b/test/oas2-request-header-date-correct-regex.spec.js
@@ -38,7 +38,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'Date header should not use the built-in OpenAPI format. Instead, \'pattern\' should be used to specify a custom format (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'HTTP headers follow the syntax specified in the corresponding RFCs.; The regex pattern used does not pass basic linting sample checks - should not have matched case Thu 8 Apr 2021 19:06:27 GMT (Comma required after Day of Week)',
         path: [
           'paths',
           '/test',

--- a/test/oas2-request-header-date-correct-type.spec.js
+++ b/test/oas2-request-header-date-correct-type.spec.js
@@ -39,7 +39,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'Date header should be type \'string\' and should not use the built-in OpenAPI format. Instead, \'pattern\' should be used to specify a custom format (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'HTTP headers follow the syntax specified in the corresponding RFCs.; "[0].pattern" property must be truthy',
         path: [
           'paths',
           '/test',
@@ -61,7 +61,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'Date header should be type \'string\' and should not use the built-in OpenAPI format. Instead, \'pattern\' should be used to specify a custom format (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'HTTP headers follow the syntax specified in the corresponding RFCs.; "integer" must match the pattern "^string$"',
         path: [
           'paths',
           '/test',
@@ -92,7 +92,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'Date header should be type \'string\' and should not use the built-in OpenAPI format. Instead, \'pattern\' should be used to specify a custom format (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'HTTP headers follow the syntax specified in the corresponding RFCs.; "[0].pattern" property must be truthy',
         path: [
           'paths',
           '/test',
@@ -114,7 +114,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'Date header should be type \'string\' and should not use the built-in OpenAPI format. Instead, \'pattern\' should be used to specify a custom format (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'HTTP headers follow the syntax specified in the corresponding RFCs.; "format" property must be falsy',
         path: [
           'paths',
           '/test',

--- a/test/oas2-request-header-if-match-is-string.spec.js
+++ b/test/oas2-request-header-if-match-is-string.spec.js
@@ -38,7 +38,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'If-Match must be a string (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'HTTP headers follow the syntax specified in the corresponding RFCs.; "integer" must match the pattern "^string$"',
         path: [
           'paths',
           '/test',

--- a/test/oas2-request-header-if-none-match-is-string.spec.js
+++ b/test/oas2-request-header-if-none-match-is-string.spec.js
@@ -38,7 +38,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'If-None-Match must be a string (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'HTTP headers follow the syntax specified in the corresponding RFCs.; "integer" must match the pattern "^string$"',
         path: [
           'paths',
           '/test',

--- a/test/oas2-request-header-if-range-is-string.spec.js
+++ b/test/oas2-request-header-if-range-is-string.spec.js
@@ -38,7 +38,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'If-Range must be a string (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'HTTP headers follow the syntax specified in the corresponding RFCs.; "integer" must match the pattern "^string$"',
         path: [
           'paths',
           '/test',

--- a/test/oas2-tracking-id-header-string-requirement.spec.js
+++ b/test/oas2-tracking-id-header-string-requirement.spec.js
@@ -37,7 +37,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: '\'TrackingID\' header should be a string in order to accommodate a UUID (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: '\'TrackingID\' header should be a string in order to accommodate a UUID.; "integer" must match the pattern "^string$"',
         path: [
           'paths',
           '/test',

--- a/test/oas3-acceptable-auth.spec.js
+++ b/test/oas3-acceptable-auth.spec.js
@@ -37,7 +37,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: 'oas3-acceptable-auth',
-        message: 'My API authenticates requests using access tokens; NOT username/passwords.; My API authenticates requests using access tokens; NOT username/passwords.',
+        message: 'My API authenticates requests using access tokens; NOT username/passwords.',
         path: [
           'components',
           'securitySchemes',
@@ -64,7 +64,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: 'oas3-acceptable-auth',
-        message: 'My API authenticates requests using access tokens; NOT username/passwords.; My API authenticates requests using access tokens; NOT username/passwords.',
+        message: 'My API authenticates requests using access tokens; NOT username/passwords.',
         path: [
           'components',
           'securitySchemes',

--- a/test/oas3-acceptable-auth.spec.js
+++ b/test/oas3-acceptable-auth.spec.js
@@ -37,7 +37,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: 'oas3-acceptable-auth',
-        message: 'My API authenticates requests using access tokens; NOT username/passwords. (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'My API authenticates requests using access tokens; NOT username/passwords.; My API authenticates requests using access tokens; NOT username/passwords.',
         path: [
           'components',
           'securitySchemes',
@@ -64,7 +64,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: 'oas3-acceptable-auth',
-        message: 'My API authenticates requests using access tokens; NOT username/passwords. (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'My API authenticates requests using access tokens; NOT username/passwords.; My API authenticates requests using access tokens; NOT username/passwords.',
         path: [
           'components',
           'securitySchemes',

--- a/test/oas3-application-json-charset-utf8-required.spec.js
+++ b/test/oas3-application-json-charset-utf8-required.spec.js
@@ -37,7 +37,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'JSON representations should be declared using \'application/json\' or \'application/json; charset=UTF-8\' media types (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'JSON representations should be declared using \'application/json\' or \'application/json; charset=UTF-8\' media types.; Object{} must not match the pattern "^application/json; charset=(?![Uu][Tt][Ff]-8$)"',
         path: [
           'paths',
           '/test',

--- a/test/oas3-array-plural-representation.spec.js
+++ b/test/oas3-array-plural-representation.spec.js
@@ -38,7 +38,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'Representation fields use plural noun names for collections (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Representation fields use plural noun names for collections.; device should be plural.',
         path: [
           'paths',
           '/test',
@@ -65,7 +65,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'Representation fields use plural noun names for collections (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Representation fields use plural noun names for collections.; contract should be plural.',
         path: [
           'paths',
           '/test',
@@ -95,7 +95,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'Representation fields use plural noun names for collections (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Representation fields use plural noun names for collections.; balance should be plural.',
         path: [
           'paths',
           '/test',

--- a/test/oas3-collections-returned-as-arrays.spec.js
+++ b/test/oas3-collections-returned-as-arrays.spec.js
@@ -37,7 +37,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'Collections should be encapsulated within an object. Do not return un-encapsulated arrays (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Collections are returned as arrays encapsulated with a named field such as \'items\'.; "array" must not match the pattern "^array$"',
         path: [
           'paths',
           '/test',
@@ -63,7 +63,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'Collections should be encapsulated within an object. Do not return un-encapsulated arrays (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Collections are returned as arrays encapsulated with a named field such as \'items\'.; "array" must not match the pattern "^array$"',
         path: [
           'paths',
           '/test',
@@ -96,7 +96,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'Collections should be encapsulated within an object. Do not return un-encapsulated arrays (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Collections are returned as arrays encapsulated with a named field such as \'items\'.; "array" must not match the pattern "^array$"',
         path: [
           'paths',
           '/test',
@@ -129,7 +129,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'Collections should be encapsulated within an object. Do not return un-encapsulated arrays (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Collections are returned as arrays encapsulated with a named field such as \'items\'.; "array" must not match the pattern "^array$"',
         path: [
           'paths',
           '/test',
@@ -155,7 +155,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'Collections should be encapsulated within an object. Do not return un-encapsulated arrays (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Collections are returned as arrays encapsulated with a named field such as \'items\'.; "array" must not match the pattern "^array$"',
         path: [
           'paths',
           '/test',

--- a/test/oas3-date-fields-iso-format.spec.js
+++ b/test/oas3-date-fields-iso-format.spec.js
@@ -38,7 +38,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'Representation fields use strings in \'iso-date-time\' format (RFC-3339) for date/time (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Representation fields use strings in \'iso-date-time\' format (RFC-3339) for date/time.; Field timestamp should be type "string" with a format of "date-time".',
         path: [
           'paths',
           '/test',
@@ -68,7 +68,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'Representation fields use strings in \'iso-date-time\' format (RFC-3339) for date/time (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Representation fields use strings in \'iso-date-time\' format (RFC-3339) for date/time.; Field requestDate should be type "string" with a format of "date-time".',
         path: [
           'paths',
           '/test',
@@ -95,7 +95,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'Representation fields use strings in \'iso-date-time\' format (RFC-3339) for date/time (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Representation fields use strings in \'iso-date-time\' format (RFC-3339) for date/time.; Field date should be type "string" with a format of "date-time".',
         path: [
           'paths',
           '/test',
@@ -122,7 +122,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'Representation fields use strings in \'iso-date-time\' format (RFC-3339) for date/time (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Representation fields use strings in \'iso-date-time\' format (RFC-3339) for date/time.; Field dates\'s items should be type "string" with a format of "date-time".',
         path: [
           'paths',
           '/test',

--- a/test/oas3-error-message.spec.js
+++ b/test/oas3-error-message.spec.js
@@ -37,7 +37,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'Error representations include a useful human-readable message. (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Error representations include a useful human-readable message.; Error representations include a useful human-readable message.',
         path: [
           'paths',
           '/test',
@@ -59,7 +59,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'Error representations include a useful human-readable message. (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Error representations include a useful human-readable message.; Error representations include a useful human-readable message.',
         path: [
           'paths',
           '/test',
@@ -100,7 +100,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'Error representations include a useful human-readable message. (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Error representations include a useful human-readable message.; Error representations include a useful human-readable message.',
         path: [
           'paths',
           '/test',
@@ -122,7 +122,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'Error representations include a useful human-readable message. (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Error representations include a useful human-readable message.; Error representations include a useful human-readable message.',
         path: [
           'paths',
           '/test',

--- a/test/oas3-error-message.spec.js
+++ b/test/oas3-error-message.spec.js
@@ -37,7 +37,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'Error representations include a useful human-readable message.; Error representations include a useful human-readable message.',
+        message: 'Error representations include a useful human-readable message.',
         path: [
           'paths',
           '/test',
@@ -59,7 +59,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'Error representations include a useful human-readable message.; Error representations include a useful human-readable message.',
+        message: 'Error representations include a useful human-readable message.',
         path: [
           'paths',
           '/test',
@@ -100,7 +100,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'Error representations include a useful human-readable message.; Error representations include a useful human-readable message.',
+        message: 'Error representations include a useful human-readable message.',
         path: [
           'paths',
           '/test',
@@ -122,7 +122,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'Error representations include a useful human-readable message.; Error representations include a useful human-readable message.',
+        message: 'Error representations include a useful human-readable message.',
         path: [
           'paths',
           '/test',

--- a/test/oas3-error-response-identifier.spec.js
+++ b/test/oas3-error-response-identifier.spec.js
@@ -38,7 +38,7 @@ describe(ruleName, () => {
       expect(res).toEqual([
         {
           code: ruleName,
-          message: 'Error representations include an identifier to help with troubleshooting.; Error representations include an identifier to help with troubleshooting.',
+          message: 'Error representations include an identifier to help with troubleshooting.',
           path: [
             'paths',
             '/test',
@@ -60,7 +60,7 @@ describe(ruleName, () => {
         },
         {
           code: ruleName,
-          message: 'Error representations include an identifier to help with troubleshooting.; Error representations include an identifier to help with troubleshooting.',
+          message: 'Error representations include an identifier to help with troubleshooting.',
           path: [
             'paths',
             '/test',

--- a/test/oas3-error-response-identifier.spec.js
+++ b/test/oas3-error-response-identifier.spec.js
@@ -38,7 +38,7 @@ describe(ruleName, () => {
       expect(res).toEqual([
         {
           code: ruleName,
-          message: 'Error representations include an identifier to help with troubleshooting (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+          message: 'Error representations include an identifier to help with troubleshooting.; Error representations include an identifier to help with troubleshooting.',
           path: [
             'paths',
             '/test',
@@ -60,7 +60,7 @@ describe(ruleName, () => {
         },
         {
           code: ruleName,
-          message: 'Error representations include an identifier to help with troubleshooting (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+          message: 'Error representations include an identifier to help with troubleshooting.; Error representations include an identifier to help with troubleshooting.',
           path: [
             'paths',
             '/test',

--- a/test/oas3-field-names-pas-camel-case.spec.js
+++ b/test/oas3-field-names-pas-camel-case.spec.js
@@ -37,7 +37,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'user_id (paths./test.post.parameters.0.name) field is not PasCamelCase (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Representation field names use PasCamelCase.; user_id (paths./test.post.parameters.0.name)',
         path: [
           'paths',
           '/test',
@@ -59,7 +59,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'MYData (paths./test.post.requestBody.content.application/json.schema.properties.MYData) field is not PasCamelCase (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Representation field names use PasCamelCase.; MYData (paths./test.post.requestBody.content.application/json.schema.properties.MYData)',
         path: [
           'paths',
           '/test',
@@ -86,7 +86,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'MYData (paths./test.post.responses.200.content.application/json.schema.items.properties.MYData) field is not PasCamelCase (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Representation field names use PasCamelCase.; MYData (paths./test.post.responses.200.content.application/json.schema.items.properties.MYData)',
         path: [
           'paths',
           '/test',
@@ -123,7 +123,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'snake_case (paths./test.get.responses.200.content.application/json.schema.items.properties.snake_case) field is not PasCamelCase (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Representation field names use PasCamelCase.; snake_case (paths./test.get.responses.200.content.application/json.schema.items.properties.snake_case)',
         path: [
           'paths',
           '/test',

--- a/test/oas3-get-collection-max-parameter-link-header-required-likely.spec.js
+++ b/test/oas3-get-collection-max-parameter-link-header-required-likely.spec.js
@@ -38,7 +38,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'When returning a paginated collection, include a "max" query parameter (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Pagination is designed using a \'max\' query parameter and \'Link\' headers per RFC 5988.; When returning a paginated collection, include a "max" query parameter',
         path: [
           'paths',
           '/test',
@@ -58,7 +58,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'When returning a paginated collection, include a "Link" header in the response (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Pagination is designed using a \'max\' query parameter and \'Link\' headers per RFC 5988.; When returning a paginated collection, include a "Link" header in the response',
         path: [
           'paths',
           '/test',
@@ -87,7 +87,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'When returning a paginated collection, include a "max" query parameter (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Pagination is designed using a \'max\' query parameter and \'Link\' headers per RFC 5988.; When returning a paginated collection, include a "max" query parameter',
         path: [
           'paths',
           '/test',
@@ -107,7 +107,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'When returning a paginated collection, include a "Link" header in the response (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Pagination is designed using a \'max\' query parameter and \'Link\' headers per RFC 5988.; When returning a paginated collection, include a "Link" header in the response',
         path: [
           'paths',
           '/test',
@@ -142,7 +142,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'When returning a paginated collection, include a "max" query parameter (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Pagination is designed using a \'max\' query parameter and \'Link\' headers per RFC 5988.; When returning a paginated collection, include a "max" query parameter',
         path: [
           'paths',
           '/test',
@@ -169,7 +169,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'When returning a paginated collection, include a "Link" header in the response (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Pagination is designed using a \'max\' query parameter and \'Link\' headers per RFC 5988.; When returning a paginated collection, include a "Link" header in the response',
         path: [
           'paths',
           '/test',
@@ -198,7 +198,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'When returning a paginated collection, include a "max" query parameter (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Pagination is designed using a \'max\' query parameter and \'Link\' headers per RFC 5988.; When returning a paginated collection, include a "max" query parameter',
         path: [
           'paths',
           '/test/{id}/children',
@@ -218,7 +218,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'When returning a paginated collection, include a "Link" header in the response (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Pagination is designed using a \'max\' query parameter and \'Link\' headers per RFC 5988.; When returning a paginated collection, include a "Link" header in the response',
         path: [
           'paths',
           '/test/{id}/children',

--- a/test/oas3-get-collection-max-parameter-link-header-required-possible.spec.js
+++ b/test/oas3-get-collection-max-parameter-link-header-required-possible.spec.js
@@ -37,7 +37,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'When returning a paginated collection, include a "max" query parameter (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Pagination is designed using a \'max\' query parameter and \'Link\' headers per RFC 5988.; When returning a paginated collection, include a "max" query parameter',
         path: [
           'paths',
           '/test',
@@ -57,7 +57,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'When supporting offset-based pagination, operations include a "offset" query parameter (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Pagination is designed using a \'max\' query parameter and \'Link\' headers per RFC 5988.; When supporting offset-based pagination, operations include a "offset" query parameter',
         path: [
           'paths',
           '/test',
@@ -77,7 +77,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'When returning a paginated collection, include a "Link" header in the response (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Pagination is designed using a \'max\' query parameter and \'Link\' headers per RFC 5988.; When returning a paginated collection, include a "Link" header in the response',
         path: [
           'paths',
           '/test',
@@ -106,7 +106,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'When returning a paginated collection, include a "max" query parameter (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Pagination is designed using a \'max\' query parameter and \'Link\' headers per RFC 5988.; When returning a paginated collection, include a "max" query parameter',
         path: [
           'paths',
           '/test',
@@ -126,7 +126,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'When supporting offset-based pagination, operations include a "offset" query parameter (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Pagination is designed using a \'max\' query parameter and \'Link\' headers per RFC 5988.; When supporting offset-based pagination, operations include a "offset" query parameter',
         path: [
           'paths',
           '/test',
@@ -146,7 +146,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'When returning a paginated collection, include a "Link" header in the response (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Pagination is designed using a \'max\' query parameter and \'Link\' headers per RFC 5988.; When returning a paginated collection, include a "Link" header in the response',
         path: [
           'paths',
           '/test',
@@ -175,7 +175,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'When returning a paginated collection, include a "max" query parameter (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Pagination is designed using a \'max\' query parameter and \'Link\' headers per RFC 5988.; When returning a paginated collection, include a "max" query parameter',
         path: [
           'paths',
           '/test',
@@ -195,7 +195,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'When supporting offset-based pagination, operations include a "offset" query parameter (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Pagination is designed using a \'max\' query parameter and \'Link\' headers per RFC 5988.; When supporting offset-based pagination, operations include a "offset" query parameter',
         path: [
           'paths',
           '/test',
@@ -215,7 +215,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'When returning a paginated collection, include a "Link" header in the response (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Pagination is designed using a \'max\' query parameter and \'Link\' headers per RFC 5988.; When returning a paginated collection, include a "Link" header in the response',
         path: [
           'paths',
           '/test',
@@ -244,7 +244,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'When returning a paginated collection, include a "max" query parameter (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Pagination is designed using a \'max\' query parameter and \'Link\' headers per RFC 5988.; When returning a paginated collection, include a "max" query parameter',
         path: [
           'paths',
           '/test',
@@ -271,7 +271,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'When supporting offset-based pagination, operations include a "offset" query parameter (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Pagination is designed using a \'max\' query parameter and \'Link\' headers per RFC 5988.; When supporting offset-based pagination, operations include a "offset" query parameter',
         path: [
           'paths',
           '/test',
@@ -298,7 +298,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'When returning a paginated collection, include a "Link" header in the response (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Pagination is designed using a \'max\' query parameter and \'Link\' headers per RFC 5988.; When returning a paginated collection, include a "Link" header in the response',
         path: [
           'paths',
           '/test',
@@ -327,7 +327,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'When returning a paginated collection, include a "max" query parameter (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Pagination is designed using a \'max\' query parameter and \'Link\' headers per RFC 5988.; When returning a paginated collection, include a "max" query parameter',
         path: [
           'paths',
           '/test/{id}/children',
@@ -347,7 +347,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'When supporting offset-based pagination, operations include a "offset" query parameter (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Pagination is designed using a \'max\' query parameter and \'Link\' headers per RFC 5988.; When supporting offset-based pagination, operations include a "offset" query parameter',
         path: [
           'paths',
           '/test/{id}/children',
@@ -367,7 +367,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'When returning a paginated collection, include a "Link" header in the response (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Pagination is designed using a \'max\' query parameter and \'Link\' headers per RFC 5988.; When returning a paginated collection, include a "Link" header in the response',
         path: [
           'paths',
           '/test/{id}/children',

--- a/test/oas3-get-collection-sort-parameter.spec.js
+++ b/test/oas3-get-collection-sort-parameter.spec.js
@@ -38,7 +38,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'It is recommended to add a "sort" query parameter to sort this collection (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Sorting collections is designed with a \'sort\' query parameter.; It is recommended to add a "sort" query parameter to sort this collection',
         path: [
           'paths',
           '/test',
@@ -65,7 +65,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'It is recommended to add a "sort" query parameter to sort this collection (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Sorting collections is designed with a \'sort\' query parameter.; It is recommended to add a "sort" query parameter to sort this collection',
         path: [
           'paths',
           '/test',

--- a/test/oas3-head-operations-no-body.spec.js
+++ b/test/oas3-head-operations-no-body.spec.js
@@ -37,7 +37,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'HEAD operations with a corresponding GET operation must return no body content (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'HEAD operations with a corresponding GET operation must return no body content.; "content" property must be falsy',
         path: [
           'paths',
           '/test',

--- a/test/oas3-https-only.spec.js
+++ b/test/oas3-https-only.spec.js
@@ -37,7 +37,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'My API supports HTTPS only. (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'My API supports HTTPS only.; "http://api.example.com/v1" must match the pattern "^https://"',
         path: [
           'servers',
           '0',

--- a/test/oas3-jwt-format.spec.js
+++ b/test/oas3-jwt-format.spec.js
@@ -37,7 +37,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'My API access tokens are passed via the HTTP \'Authorization\' header, with a \'Bearer\' prefix. Need to add "bearerFormat: jwt". (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'My API access tokens are passed via the HTTP \'Authorization\' header, with a \'Bearer\' prefix.; "Bearer.bearerFormat" property must be truthy',
         path: [
           'components',
           'securitySchemes',

--- a/test/oas3-no-boolean-string-enums.spec.js
+++ b/test/oas3-no-boolean-string-enums.spec.js
@@ -37,7 +37,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'Representation fields use format-native true/false values for booleans (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Representation fields use format-native true/false values for booleans.; Given matches target enums.',
         path: [
           'paths',
           '/test',
@@ -72,7 +72,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'Representation fields use format-native true/false values for booleans (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Representation fields use format-native true/false values for booleans.; Given matches target enums.',
         path: [
           'paths',
           '/test',
@@ -107,7 +107,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'Representation fields use format-native true/false values for booleans (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Representation fields use format-native true/false values for booleans.; Given matches target enums.',
         path: [
           'paths',
           '/test',
@@ -143,7 +143,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'Representation fields use format-native true/false values for booleans (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Representation fields use format-native true/false values for booleans.; Given matches target enums.',
         path: [
           'paths',
           '/test',
@@ -182,7 +182,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'Representation fields use format-native true/false values for booleans (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Representation fields use format-native true/false values for booleans.; Given matches target enums.',
         path: [
           'paths',
           '/test',
@@ -218,7 +218,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'Representation fields use format-native true/false values for booleans (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Representation fields use format-native true/false values for booleans.; Given matches target enums.',
         path: [
           'paths',
           '/test',

--- a/test/oas3-order-parameter-asc-desc.spec.js
+++ b/test/oas3-order-parameter-asc-desc.spec.js
@@ -37,7 +37,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'Ordering collections is designed with an \'order\' query parameter specifying \'asc\' or \'desc\' (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Ordering collections is designed with an \'order\' query parameter specifying \'asc\' or \'desc\'.; "integer" must match the pattern "^string$"',
         path: [
           'paths',
           '/test',
@@ -68,7 +68,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'Ordering collections is designed with an \'order\' query parameter specifying \'asc\' or \'desc\' (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Ordering collections is designed with an \'order\' query parameter specifying \'asc\' or \'desc\'.; Given does not match target enums.',
         path: [
           'paths',
           '/test',

--- a/test/oas3-path-based-versioning-error.spec.js
+++ b/test/oas3-path-based-versioning-error.spec.js
@@ -37,7 +37,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'API uses path-based versioning. (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'API uses path-based versioning.; API uses path-based versioning.',
         path: [],
         range: {
           start: {

--- a/test/oas3-path-based-versioning-error.spec.js
+++ b/test/oas3-path-based-versioning-error.spec.js
@@ -37,7 +37,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'API uses path-based versioning.; API uses path-based versioning.',
+        message: 'API uses path-based versioning.',
         path: [],
         range: {
           start: {

--- a/test/oas3-path-based-versioning-major-only.spec.js
+++ b/test/oas3-path-based-versioning-major-only.spec.js
@@ -37,7 +37,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'API shows only major version numbers on the path; not the revision numbers. (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'API shows only major version numbers on the path; not the revision numbers.; API shows only major version numbers on the path; not the revision numbers.',
         path: [],
         range: {
           start: {

--- a/test/oas3-post-201-created.spec.js
+++ b/test/oas3-post-201-created.spec.js
@@ -37,7 +37,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'POST operations which create objects return 201 Created, with a full or reference-only representation. (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'POST operations which create objects return 201 Created, with a full or reference-only representation.; "[201].content" property must be truthy',
         path: [
           'paths',
           '/test',
@@ -59,7 +59,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'POST operations which create objects return 201 Created, with a full or reference-only representation. (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'POST operations which create objects return 201 Created, with a full or reference-only representation.; "[201].content" property must be truthy',
         path: [
           'paths',
           '/other/test',

--- a/test/oas3-request-header-accept-charset-default-required.spec.js
+++ b/test/oas3-request-header-accept-charset-default-required.spec.js
@@ -38,7 +38,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'Accept-Charset must have a default defined (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'HTTP headers follow the syntax specified in the corresponding RFCs.; "schema.default" property must be truthy',
         path: [
           'paths',
           '/test',

--- a/test/oas3-request-header-accept-charset-valid-default.spec.js
+++ b/test/oas3-request-header-accept-charset-valid-default.spec.js
@@ -38,7 +38,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'Default for Accept-Charset must be UTF-8 (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'HTTP headers follow the syntax specified in the corresponding RFCs.; "test" must match the pattern "^[Uu][Tt][Ff]-8$"',
         path: [
           'paths',
           '/test',

--- a/test/oas3-request-header-accept-charset-valid-enum.spec.js
+++ b/test/oas3-request-header-accept-charset-valid-enum.spec.js
@@ -38,7 +38,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'Accept-Charset must allow UTF-8 and ISO-8859-1. (The following values are missing from the enum: ISO-8859-1.) (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'HTTP headers follow the syntax specified in the corresponding RFCs.; The following values are missing from the enum: ISO-8859-1.',
         path: [
           'paths',
           '/test',

--- a/test/oas3-request-header-accept-encoding-enum.spec.js
+++ b/test/oas3-request-header-accept-encoding-enum.spec.js
@@ -38,7 +38,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'Accept-Encoding should have a list of accepted values (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'HTTP headers follow the syntax specified in the corresponding RFCs.; "schema.enum" property must be truthy',
         path: [
           'paths',
           '/test',

--- a/test/oas3-request-header-accept-encoding-valid-enum.spec.js
+++ b/test/oas3-request-header-accept-encoding-valid-enum.spec.js
@@ -38,7 +38,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'Accept-Encoding accepts a value that is not valid per RFC 7231. (The following values must be removed: notvalid.) (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer) Please see https://www.iana.org/assignments/http-parameters/http-parameters.xhtml',
+        message: 'HTTP headers follow the syntax specified in the corresponding RFCs.; The following values must be removed: notvalid.',
         path: [
           'paths',
           '/test',

--- a/test/oas3-request-header-accept-language-enum.spec.js
+++ b/test/oas3-request-header-accept-language-enum.spec.js
@@ -38,7 +38,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'Accept-Language should have a list of accepted values (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'HTTP headers follow the syntax specified in the corresponding RFCs.; "schema.enum" property must be truthy',
         path: [
           'paths',
           '/test',

--- a/test/oas3-request-header-date-correct-regex.spec.js
+++ b/test/oas3-request-header-date-correct-regex.spec.js
@@ -38,7 +38,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'Date header should not use the built-in OpenAPI format. Instead, \'pattern\' should be used to specify a custom format (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'HTTP headers follow the syntax specified in the corresponding RFCs.; The regex pattern used does not pass basic linting sample checks - should not have matched case Thu 8 Apr 2021 19:06:27 GMT (Comma required after Day of Week)',
         path: [
           'paths',
           '/test',

--- a/test/oas3-request-header-date-correct-type.spec.js
+++ b/test/oas3-request-header-date-correct-type.spec.js
@@ -39,7 +39,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'Date header should be type \'string\' and should not use the built-in OpenAPI format. Instead, \'pattern\' should be used to specify a custom format (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'HTTP headers follow the syntax specified in the corresponding RFCs.; "schema.pattern" property must be truthy',
         path: [
           'paths',
           '/test',
@@ -62,7 +62,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'Date header should be type \'string\' and should not use the built-in OpenAPI format. Instead, \'pattern\' should be used to specify a custom format (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'HTTP headers follow the syntax specified in the corresponding RFCs.; "integer" must match the pattern "^string$"',
         path: [
           'paths',
           '/test',
@@ -94,7 +94,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'Date header should be type \'string\' and should not use the built-in OpenAPI format. Instead, \'pattern\' should be used to specify a custom format (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'HTTP headers follow the syntax specified in the corresponding RFCs.; "schema.pattern" property must be truthy',
         path: [
           'paths',
           '/test',
@@ -117,7 +117,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'Date header should be type \'string\' and should not use the built-in OpenAPI format. Instead, \'pattern\' should be used to specify a custom format (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'HTTP headers follow the syntax specified in the corresponding RFCs.; "format" property must be falsy',
         path: [
           'paths',
           '/test',

--- a/test/oas3-request-header-if-match-is-string.spec.js
+++ b/test/oas3-request-header-if-match-is-string.spec.js
@@ -38,7 +38,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'If-Match must be a string (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'HTTP headers follow the syntax specified in the corresponding RFCs.; "integer" must match the pattern "^string$"',
         path: [
           'paths',
           '/test',

--- a/test/oas3-request-header-if-none-match-is-string.spec.js
+++ b/test/oas3-request-header-if-none-match-is-string.spec.js
@@ -38,7 +38,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'If-None-Match must be a string (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'HTTP headers follow the syntax specified in the corresponding RFCs.; "integer" must match the pattern "^string$"',
         path: [
           'paths',
           '/test',

--- a/test/oas3-request-header-if-range-is-string.spec.js
+++ b/test/oas3-request-header-if-range-is-string.spec.js
@@ -38,7 +38,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'If-Range must be a string (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'HTTP headers follow the syntax specified in the corresponding RFCs.; "integer" must match the pattern "^string$"',
         path: [
           'paths',
           '/test',

--- a/test/oas3-tracking-id-header-string-requirement.spec.js
+++ b/test/oas3-tracking-id-header-string-requirement.spec.js
@@ -37,7 +37,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: '\'TrackingID\' header should be a string in order to accommodate a UUID (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: '\'TrackingID\' header should be a string in order to accommodate a UUID.; "integer" must match the pattern "^string$"',
         path: [
           'paths',
           '/test',

--- a/test/patch-200-204-success.spec.js
+++ b/test/patch-200-204-success.spec.js
@@ -36,7 +36,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'PATCH operations return either \'200 OK\' with full representation or \'204 No Content\' (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'PATCH operations return either \'200 OK\' with full representation or \'204 No Content\'.; PATCH operations return either \'200 OK\' with full representation or \'204 No Content\'.',
         path: [
           'paths',
           '/test',
@@ -63,7 +63,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'PATCH operations return either \'200 OK\' with full representation or \'204 No Content\' (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'PATCH operations return either \'200 OK\' with full representation or \'204 No Content\'.; PATCH operations return either \'200 OK\' with full representation or \'204 No Content\'.',
         path: [
           'paths',
           '/test',
@@ -90,7 +90,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'PATCH operations return either \'200 OK\' with full representation or \'204 No Content\' (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'PATCH operations return either \'200 OK\' with full representation or \'204 No Content\'.; PATCH operations return either \'200 OK\' with full representation or \'204 No Content\'.',
         path: [
           'paths',
           '/test',
@@ -131,7 +131,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'PATCH operations return either \'200 OK\' with full representation or \'204 No Content\' (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'PATCH operations return either \'200 OK\' with full representation or \'204 No Content\'.; PATCH operations return either \'200 OK\' with full representation or \'204 No Content\'.',
         path: [
           'paths',
           '/test',
@@ -158,7 +158,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'PATCH operations return either \'200 OK\' with full representation or \'204 No Content\' (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'PATCH operations return either \'200 OK\' with full representation or \'204 No Content\'.; PATCH operations return either \'200 OK\' with full representation or \'204 No Content\'.',
         path: [
           'paths',
           '/test',
@@ -186,7 +186,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'PATCH operations return either \'200 OK\' with full representation or \'204 No Content\' (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'PATCH operations return either \'200 OK\' with full representation or \'204 No Content\'.; PATCH operations return either \'200 OK\' with full representation or \'204 No Content\'.',
         path: [
           'paths',
           '/test',

--- a/test/patch-200-204-success.spec.js
+++ b/test/patch-200-204-success.spec.js
@@ -36,7 +36,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'PATCH operations return either \'200 OK\' with full representation or \'204 No Content\'.; PATCH operations return either \'200 OK\' with full representation or \'204 No Content\'.',
+        message: 'PATCH operations return either \'200 OK\' with full representation or \'204 No Content\'.',
         path: [
           'paths',
           '/test',
@@ -63,7 +63,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'PATCH operations return either \'200 OK\' with full representation or \'204 No Content\'.; PATCH operations return either \'200 OK\' with full representation or \'204 No Content\'.',
+        message: 'PATCH operations return either \'200 OK\' with full representation or \'204 No Content\'.',
         path: [
           'paths',
           '/test',
@@ -90,7 +90,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'PATCH operations return either \'200 OK\' with full representation or \'204 No Content\'.; PATCH operations return either \'200 OK\' with full representation or \'204 No Content\'.',
+        message: 'PATCH operations return either \'200 OK\' with full representation or \'204 No Content\'.',
         path: [
           'paths',
           '/test',
@@ -131,7 +131,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'PATCH operations return either \'200 OK\' with full representation or \'204 No Content\'.; PATCH operations return either \'200 OK\' with full representation or \'204 No Content\'.',
+        message: 'PATCH operations return either \'200 OK\' with full representation or \'204 No Content\'.',
         path: [
           'paths',
           '/test',
@@ -158,7 +158,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'PATCH operations return either \'200 OK\' with full representation or \'204 No Content\'.; PATCH operations return either \'200 OK\' with full representation or \'204 No Content\'.',
+        message: 'PATCH operations return either \'200 OK\' with full representation or \'204 No Content\'.',
         path: [
           'paths',
           '/test',
@@ -186,7 +186,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'PATCH operations return either \'200 OK\' with full representation or \'204 No Content\'.; PATCH operations return either \'200 OK\' with full representation or \'204 No Content\'.',
+        message: 'PATCH operations return either \'200 OK\' with full representation or \'204 No Content\'.',
         path: [
           'paths',
           '/test',

--- a/test/post-header-location.spec.js
+++ b/test/post-header-location.spec.js
@@ -36,7 +36,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'POST operations that create resources should include a Location header (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'POST operations that create resources should include a Location header.; "headers.Location" property must be truthy',
         path: [
           'paths',
           '/test',
@@ -59,7 +59,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'POST operations that create resources should include a Location header (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'POST operations that create resources should include a Location header.; "headers.Location" property must be truthy',
         path: [
           'paths',
           '/anotherTest',
@@ -95,7 +95,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'POST operations that create resources should include a Location header (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'POST operations that create resources should include a Location header.; "headers.Location" property must be truthy',
         path: [
           'paths',
           '/test',
@@ -118,7 +118,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'POST operations that create resources should include a Location header (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'POST operations that create resources should include a Location header.; "headers.Location" property must be truthy',
         path: [
           'paths',
           '/anotherTest',

--- a/test/post-header.spec.js
+++ b/test/post-header.spec.js
@@ -36,7 +36,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'POST operations that create resources should include a Location header (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'POST operations that create resources should include a Location header.; "[201].headers" property must be truthy',
         path: [
           'paths',
           '/test',
@@ -71,7 +71,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'POST operations that create resources should include a Location header (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'POST operations that create resources should include a Location header.; "[201].headers" property must be truthy',
         path: [
           'paths',
           '/test',

--- a/test/put-200-204-success.spec.js
+++ b/test/put-200-204-success.spec.js
@@ -36,7 +36,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'PUT operations return either \'200 OK\' with full representation or \'204 No Content\'.; PUT operations return either \'200 OK\' with full representation or \'204 No Content\'.',
+        message: 'PUT operations return either \'200 OK\' with full representation or \'204 No Content\'.',
         path: [
           'paths',
           '/test',
@@ -63,7 +63,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'PUT operations return either \'200 OK\' with full representation or \'204 No Content\'.; PUT operations return either \'200 OK\' with full representation or \'204 No Content\'.',
+        message: 'PUT operations return either \'200 OK\' with full representation or \'204 No Content\'.',
         path: [
           'paths',
           '/test',
@@ -90,7 +90,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'PUT operations return either \'200 OK\' with full representation or \'204 No Content\'.; PUT operations return either \'200 OK\' with full representation or \'204 No Content\'.',
+        message: 'PUT operations return either \'200 OK\' with full representation or \'204 No Content\'.',
         path: [
           'paths',
           '/test',
@@ -117,7 +117,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'PUT operations return either \'200 OK\' with full representation or \'204 No Content\'.; PUT operations return either \'200 OK\' with full representation or \'204 No Content\'.',
+        message: 'PUT operations return either \'200 OK\' with full representation or \'204 No Content\'.',
         path: [
           'paths',
           '/test',

--- a/test/put-200-204-success.spec.js
+++ b/test/put-200-204-success.spec.js
@@ -36,7 +36,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'PUT operations return either \'200 OK\' with full representation or \'204 No Content\' (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'PUT operations return either \'200 OK\' with full representation or \'204 No Content\'.; PUT operations return either \'200 OK\' with full representation or \'204 No Content\'.',
         path: [
           'paths',
           '/test',
@@ -63,7 +63,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'PUT operations return either \'200 OK\' with full representation or \'204 No Content\' (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'PUT operations return either \'200 OK\' with full representation or \'204 No Content\'.; PUT operations return either \'200 OK\' with full representation or \'204 No Content\'.',
         path: [
           'paths',
           '/test',
@@ -90,7 +90,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'PUT operations return either \'200 OK\' with full representation or \'204 No Content\' (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'PUT operations return either \'200 OK\' with full representation or \'204 No Content\'.; PUT operations return either \'200 OK\' with full representation or \'204 No Content\'.',
         path: [
           'paths',
           '/test',
@@ -117,7 +117,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'PUT operations return either \'200 OK\' with full representation or \'204 No Content\' (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'PUT operations return either \'200 OK\' with full representation or \'204 No Content\'.; PUT operations return either \'200 OK\' with full representation or \'204 No Content\'.',
         path: [
           'paths',
           '/test',

--- a/test/resource-name-too-long.spec.js
+++ b/test/resource-name-too-long.spec.js
@@ -36,7 +36,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: '"veryLongEndpoint" is longer than allowed maximum of 15 (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Resource names are consistent and succinct; do not use abbreviations.; "veryLongEndpoint" is longer than allowed maximum of 15',
         path: [
           'paths',
           '/veryLongEndpoint',
@@ -55,7 +55,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: '"someLongEndpoint" is longer than allowed maximum of 15 (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Resource names are consistent and succinct; do not use abbreviations.; "someLongEndpoint" is longer than allowed maximum of 15',
         path: [
           'paths',
           '/veryLongEndpoint/someLongEndpoint',
@@ -74,7 +74,7 @@ describe(ruleName, () => {
       },
       {
         code: 'resource-name-too-long',
-        message: '"veryLongEndpoint" is longer than allowed maximum of 15 (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Resource names are consistent and succinct; do not use abbreviations.; "veryLongEndpoint" is longer than allowed maximum of 15',
         path: [
           'paths',
           '/other/veryLongEndpoint',
@@ -93,7 +93,7 @@ describe(ruleName, () => {
       },
       {
         code: 'resource-name-too-long',
-        message: '"veryVeryVeryLongEndpoint" is longer than allowed maximum of 15 (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Resource names are consistent and succinct; do not use abbreviations.; "veryVeryVeryLongEndpoint" is longer than allowed maximum of 15',
         path: [
           'paths',
           '/veryVeryVeryLongEndpoint',

--- a/test/resource-pas-camel-case-error.spec.js
+++ b/test/resource-pas-camel-case-error.spec.js
@@ -36,7 +36,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'snake_case must be PasCamelCase: (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Resource names use PasCamelCase.; snake_case must be PasCamelCase',
         path: [
           'paths',
           '/snake_case/snake_case',
@@ -55,7 +55,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'ALLCAPS must be PasCamelCase: (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Resource names use PasCamelCase.; ALLCAPS must be PasCamelCase',
         path: [
           'paths',
           '/ALLCAPS/ALLCAPS',

--- a/test/resource-pas-camel-case-info.spec.js
+++ b/test/resource-pas-camel-case-info.spec.js
@@ -36,7 +36,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'snake_case must be PasCamelCase: (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Resource names use PasCamelCase.; snake_case must be PasCamelCase',
         path: [
           'paths',
           '/snake_case/snake_case',
@@ -55,7 +55,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'ALLCAPS must be PasCamelCase: (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Resource names use PasCamelCase.; ALLCAPS must be PasCamelCase',
         path: [
           'paths',
           '/ALLCAPS/ALLCAPS',

--- a/test/respond-with-recommended-delete-codes.spec.js
+++ b/test/respond-with-recommended-delete-codes.spec.js
@@ -42,7 +42,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: '201 is not an acceptable response code for DELETE. My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges; 201 is not an acceptable response code for DELETE. My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges',
         path: [
           'paths',
           '/myResource',
@@ -64,7 +64,7 @@ describe(ruleName, () => {
       },
       {
         code: 'respond-with-recommended-delete-codes',
-        message: '202 is not an acceptable response code for DELETE. My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges; 202 is not an acceptable response code for DELETE. My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges',
         path: [
           'paths',
           '/myResource',

--- a/test/respond-with-recommended-delete-codes.spec.js
+++ b/test/respond-with-recommended-delete-codes.spec.js
@@ -42,7 +42,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges; 201 is not an acceptable response code for DELETE. My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges',
+        message: '201 is not an acceptable response code for DELETE. My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges.',
         path: [
           'paths',
           '/myResource',
@@ -64,7 +64,7 @@ describe(ruleName, () => {
       },
       {
         code: 'respond-with-recommended-delete-codes',
-        message: 'My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges; 202 is not an acceptable response code for DELETE. My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges',
+        message: '202 is not an acceptable response code for DELETE. My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges.',
         path: [
           'paths',
           '/myResource',

--- a/test/respond-with-recommended-get-codes.spec.js
+++ b/test/respond-with-recommended-get-codes.spec.js
@@ -42,7 +42,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges; 201 is not an acceptable response code for GET. My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges',
+        message: '201 is not an acceptable response code for GET. My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges.',
         path: [
           'paths',
           '/myResource',

--- a/test/respond-with-recommended-get-codes.spec.js
+++ b/test/respond-with-recommended-get-codes.spec.js
@@ -42,7 +42,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: '201 is not an acceptable response code for GET. My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges; 201 is not an acceptable response code for GET. My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges',
         path: [
           'paths',
           '/myResource',

--- a/test/respond-with-recommended-patch-codes.spec.js
+++ b/test/respond-with-recommended-patch-codes.spec.js
@@ -42,7 +42,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges; 201 is not an acceptable response code for PATCH. My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges',
+        message: '201 is not an acceptable response code for PATCH. My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges.',
         path: [
           'paths',
           '/myResource',
@@ -64,7 +64,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges; 202 is not an acceptable response code for PATCH. My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges',
+        message: '202 is not an acceptable response code for PATCH. My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges.',
         path: [
           'paths',
           '/myResource',
@@ -86,7 +86,7 @@ describe(ruleName, () => {
       },
       {
         code: 'respond-with-recommended-patch-codes',
-        message: 'My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges; 279 is not an acceptable response code for PATCH. My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges',
+        message: '279 is not an acceptable response code for PATCH. My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges.',
         path: [
           'paths',
           '/myResource',

--- a/test/respond-with-recommended-patch-codes.spec.js
+++ b/test/respond-with-recommended-patch-codes.spec.js
@@ -42,7 +42,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: '201 is not an acceptable response code for PATCH. My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges; 201 is not an acceptable response code for PATCH. My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges',
         path: [
           'paths',
           '/myResource',
@@ -64,7 +64,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: '202 is not an acceptable response code for PATCH. My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges; 202 is not an acceptable response code for PATCH. My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges',
         path: [
           'paths',
           '/myResource',
@@ -86,7 +86,7 @@ describe(ruleName, () => {
       },
       {
         code: 'respond-with-recommended-patch-codes',
-        message: '279 is not an acceptable response code for PATCH. My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges; 279 is not an acceptable response code for PATCH. My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges',
         path: [
           'paths',
           '/myResource',

--- a/test/respond-with-recommended-post-codes.spec.js
+++ b/test/respond-with-recommended-post-codes.spec.js
@@ -42,7 +42,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges; 204 is not an acceptable response code for POST. My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges',
+        message: '204 is not an acceptable response code for POST. My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges.',
         path: [
           'paths',
           '/myResource',

--- a/test/respond-with-recommended-post-codes.spec.js
+++ b/test/respond-with-recommended-post-codes.spec.js
@@ -42,7 +42,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: '204 is not an acceptable response code for POST. My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges; 204 is not an acceptable response code for POST. My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges',
         path: [
           'paths',
           '/myResource',

--- a/test/respond-with-recommended-put-codes.spec.js
+++ b/test/respond-with-recommended-put-codes.spec.js
@@ -42,7 +42,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges; 201 is not an acceptable response code for PUT. My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges',
+        message: '201 is not an acceptable response code for PUT. My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges.',
         path: [
           'paths',
           '/myResource',

--- a/test/respond-with-recommended-put-codes.spec.js
+++ b/test/respond-with-recommended-put-codes.spec.js
@@ -42,7 +42,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: '201 is not an acceptable response code for PUT. My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges; 201 is not an acceptable response code for PUT. My API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges',
         path: [
           'paths',
           '/myResource',

--- a/test/sort-recommend-order.spec.js
+++ b/test/sort-recommend-order.spec.js
@@ -36,7 +36,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'Consider using \'order\' with \'sort\' in this operation.; Consider changing the "sort" param to an "order" param.',
+        message: 'Consider changing the "sort" param to an "order" param.',
         path: [
           'paths',
           '/test',

--- a/test/sort-recommend-order.spec.js
+++ b/test/sort-recommend-order.spec.js
@@ -36,7 +36,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'Consider using \'order\' with \'sort\' in this operation (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'Consider using \'order\' with \'sort\' in this operation.; Consider changing the "sort" param to an "order" param.',
         path: [
           'paths',
           '/test',

--- a/test/status-code-401.spec.js
+++ b/test/status-code-401.spec.js
@@ -36,7 +36,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: 'status-code-401',
-        message: 'A 401 status code is returned when authentication fails.; An expected pathway is missing. Prerequisite: "undefined", search: "401"',
+        message: 'A 401 status code is returned when authentication fails.',
         path: [
           'paths',
           '/myResource',

--- a/test/status-code-401.spec.js
+++ b/test/status-code-401.spec.js
@@ -36,7 +36,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: 'status-code-401',
-        message: 'A 401 status code is returned when authentication fails. (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'A 401 status code is returned when authentication fails.; An expected pathway is missing. Prerequisite: "undefined", search: "401"',
         path: [
           'paths',
           '/myResource',

--- a/test/status-code-403.spec.js
+++ b/test/status-code-403.spec.js
@@ -36,7 +36,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: 'status-code-403',
-        message: 'A 403 status code is returned if a consumer is not authorized to access an operation. (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'A 403 status code is returned if a consumer is not authorized to access an operation.; An expected pathway is missing. Prerequisite: "undefined", search: "403"',
         path: [
           'paths',
           '/myResource',

--- a/test/status-code-403.spec.js
+++ b/test/status-code-403.spec.js
@@ -36,7 +36,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: 'status-code-403',
-        message: 'A 403 status code is returned if a consumer is not authorized to access an operation.; An expected pathway is missing. Prerequisite: "undefined", search: "403"',
+        message: 'A 403 status code is returned if a consumer is not authorized to access an operation.',
         path: [
           'paths',
           '/myResource',

--- a/test/status-codes-in-2xx-3xx-4xx-5xx.spec.js
+++ b/test/status-codes-in-2xx-3xx-4xx-5xx.spec.js
@@ -36,7 +36,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'Status Code(s) [110] must be in the 2xx/3xx/4xx/5xx ranges: (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges.; Status Code(s) [110] must be in the 2xx/3xx/4xx/5xx ranges',
         path: [
           'paths',
           '/test',
@@ -57,7 +57,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'Status Code(s) [110] must be in the 2xx/3xx/4xx/5xx ranges: (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges.; Status Code(s) [110] must be in the 2xx/3xx/4xx/5xx ranges',
         path: [
           'paths',
           '/test',
@@ -78,7 +78,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'Status Code(s) [110] must be in the 2xx/3xx/4xx/5xx ranges: (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges.; Status Code(s) [110] must be in the 2xx/3xx/4xx/5xx ranges',
         path: [
           'paths',
           '/test',
@@ -99,7 +99,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'Status Code(s) [110] must be in the 2xx/3xx/4xx/5xx ranges: (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges.; Status Code(s) [110] must be in the 2xx/3xx/4xx/5xx ranges',
         path: [
           'paths',
           '/test',
@@ -120,7 +120,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'Status Code(s) [110] must be in the 2xx/3xx/4xx/5xx ranges: (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges.; Status Code(s) [110] must be in the 2xx/3xx/4xx/5xx ranges',
         path: [
           'paths',
           '/test',
@@ -141,7 +141,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'Status Code(s) [110] must be in the 2xx/3xx/4xx/5xx ranges: (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges.; Status Code(s) [110] must be in the 2xx/3xx/4xx/5xx ranges',
         path: [
           'paths',
           '/test',
@@ -162,7 +162,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'Status Code(s) [110] must be in the 2xx/3xx/4xx/5xx ranges: (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges.; Status Code(s) [110] must be in the 2xx/3xx/4xx/5xx ranges',
         path: [
           'paths',
           '/test',
@@ -183,7 +183,7 @@ describe(ruleName, () => {
       },
       {
         code: ruleName,
-        message: 'Status Code(s) [110] must be in the 2xx/3xx/4xx/5xx ranges: (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges.; Status Code(s) [110] must be in the 2xx/3xx/4xx/5xx ranges',
         path: [
           'paths',
           '/test',
@@ -211,7 +211,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'Status Code(s) [110] must be in the 2xx/3xx/4xx/5xx ranges: (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'API responds with recommended HTTP status codes in the 2xx/3xx/4xx/5xx ranges.; Status Code(s) [110] must be in the 2xx/3xx/4xx/5xx ranges',
         path: [
           'paths',
           '/test',

--- a/test/tracking-id-header-requirement.spec.js
+++ b/test/tracking-id-header-requirement.spec.js
@@ -36,7 +36,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'All responses must include a \'TrackingID\' header (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'All responses must include a \'TrackingID\' header.; An expected pathway is missing. Prerequisite: "headers", search: "TrackingID"',
         path: [
           'paths',
           '/test',
@@ -65,7 +65,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'All responses must include a \'TrackingID\' header (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'All responses must include a \'TrackingID\' header.; An expected pathway is missing. Prerequisite: "headers", search: "TrackingID"',
         path: [
           'paths',
           '/test',

--- a/test/tracking-id-header-requirement.spec.js
+++ b/test/tracking-id-header-requirement.spec.js
@@ -36,7 +36,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'All responses must include a \'TrackingID\' header.; An expected pathway is missing. Prerequisite: "headers", search: "TrackingID"',
+        message: 'All responses must include a \'TrackingID\' header.',
         path: [
           'paths',
           '/test',
@@ -65,7 +65,7 @@ describe(ruleName, () => {
     expect(res).toEqual([
       {
         code: ruleName,
-        message: 'All responses must include a \'TrackingID\' header.; An expected pathway is missing. Prerequisite: "headers", search: "TrackingID"',
+        message: 'All responses must include a \'TrackingID\' header.',
         path: [
           'paths',
           '/test',

--- a/util/isCollectionResponse.js
+++ b/util/isCollectionResponse.js
@@ -169,7 +169,7 @@ function handleCollectionResponse(input, opts, context, isOAS2Collection, isOAS3
 
     if (!maxQueryParameter) {
       messages.push({
-        message: 'When returning a paginated collection, include a "max" query parameter (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'When returning a paginated collection, include a "max" query parameter',
         path: [...prettyPath],
       });
     }
@@ -178,14 +178,14 @@ function handleCollectionResponse(input, opts, context, isOAS2Collection, isOAS3
     if (severity === 1 && !offsetQueryParameter) {
 
       messages.push({
-        message: 'When supporting offset-based pagination, operations include a "offset" query parameter (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'When supporting offset-based pagination, operations include a "offset" query parameter',
         path: [...prettyPath],
       });
     }
 
     if (!linkResponseHeader) {
       messages.push({
-        message: 'When returning a paginated collection, include a "Link" header in the response (https://developer.cisco.com/docs/api-insights/#!api-guidelines-analyzer)',
+        message: 'When returning a paginated collection, include a "Link" header in the response',
         path: [
           ...prettyPath,
           'responses',


### PR DESCRIPTION
As we're now passing Spectral's raw `{{description}}; {{error}}` to the end user, we should clean up the `{{error}}` by removing the unnecessary reference link as API Insights already handled mitigation/recommendation separately.

As a part of this, all tests also had to be updated to test/match against the new message format.